### PR TITLE
160 add a parent node for existing ai spawners

### DIFF
--- a/Content/Blueprints/Runners/MyAISpawnerController.uasset
+++ b/Content/Blueprints/Runners/MyAISpawnerController.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1254683fa88cfd743a32db21264c0effc245cdedb41586eba0b6fcacfaecbe95
+size 21298

--- a/Source/BroncoDrome/StageActors/AISpawner.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawner.cpp
@@ -15,11 +15,10 @@ AAISpawner::AAISpawner():AActor()
 }
 
 // Used to find out how many AI there are
-/*
 int AAISpawner::GetAmountOfAI() {
-	return amountOfAI;
+	return maxAI;
 }
-*/
+
 
 // Called when the game starts or when spawned
 void AAISpawner::BeginPlay()

--- a/Source/BroncoDrome/StageActors/AISpawner.h
+++ b/Source/BroncoDrome/StageActors/AISpawner.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "BroncoDrome/StageActors/AIActor.h"
+#include "BroncoDrome/StageActors/AISpawnerController.h"
 #include "GameFramework/Actor.h"
 #include "AISpawner.generated.h"
 

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -1,0 +1,41 @@
+// // Copyright (C) Dromies 2021. All Rights Reserved.
+/* Marking for AI team to edit*/
+
+
+#include "AISpawner.h"
+#include "AIActor.h"
+
+// Sets default values
+AAISpawnerController::AAISpawnerController() : AActor() {
+  // Set this actor to call Tick() every frame.  You can turn this off to
+  // improve performance if you don't need it.
+  PrimaryActorTick.bCanEverTick = true;
+}
+
+int AAISpawnerController::getMaxAI() { return maxAIs; }
+
+// Called when the game starts or when spawned
+void AAISpawnerController::BeginPlay() {
+	Super::BeginPlay();
+
+	// Finds all spawn points on the map and adds them to an array
+	TArray<AActor*> FoundActors;
+	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AAISpawner::StaticClass(), FoundActors);
+
+	// For debugging purposes and example of access, below iterates through spawners to show how to access spawner functions
+	int numSpawners = 0;
+    for (auto &Spwner : FoundActors) {
+        numSpawners++;
+		GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("SPAWN POINT %d MAX AI: %d"), numSpawners, ((AAISpawner*)Spwner)->GetAmountOfAI()));
+	}
+
+	// Prints number of spawners for debugging purposes
+	GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("NUMBER OF SPAWN POINTS: %d"), numSpawners));
+}
+
+// Called every frame, will currently spawn AI (at the spawner location) based on the respawn timer interval until max have spawned. AI currently do not respawn
+void AAISpawnerController::Tick(float DeltaTime) {
+	Super::Tick(DeltaTime);
+}
+
+

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -1,0 +1,34 @@
+// // Copyright (C) Dromies 2021. All Rights Reserved.
+/* Marking for AI team to edit*/
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "AISpawnerController.generated.h"
+
+UCLASS()
+class BRONCODROME_API AAISpawnerController : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	AAISpawnerController();
+  // Called every frame
+  virtual void Tick(float DeltaTime) override;
+
+  int getMaxAI();
+
+  // How often to spawn new AI, until max AI is reached
+  UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true"))
+  int respTimer = 200;
+
+  // Maximum amount of AI actors this spawner can spawn
+  UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true"))
+  int maxAIs = 5; 
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+};


### PR DESCRIPTION
Closes #160
I added a new class that connects to a new actor blueprint placeable and configurable in maps. My plan is for this new controller to control the individual spawn points and trigger spawns while the individual spawn points will not spawn on their own. This will eventually allow me to implement randomized spawning, preventing spawning if there's actors too close, etc. My original implementation idea changed slightly (as I was thinking that each actor would control their spawns by communicating with the controller versus the controller controlling spawns by communicating with the spawners), but ultimately this should have the same result and be a bit cleaner. 

Also, it's been a hot minute since I've worked with C. Let alone learning C++. Getting used to pointer referencing/dereferencing and all that jazz again has been... exciting.