### PR TITLE
Spawning Controller Spawns AI at Chosen SpawnPoints

### DIFF
--- a/Source/BroncoDrome/StageActors/AISpawner.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawner.cpp
@@ -13,9 +13,21 @@ AAISpawner::AAISpawner():AActor()
 
 }
 
-// Used to find out how many AI there are
-int AAISpawner::GetAmountOfAI() {
-	return maxAI;
+bool AAISpawner::Spawn(FName difficultySetting) 
+{
+  if ((onlySpawnOnce && amountSpawned > 0) || !spawnEnabled) return false;
+  FVector loc = GetActorLocation();
+  FRotator roc = FRotator(0, 0, 0);
+  AAIActor *ai = GetWorld()->SpawnActor<AAIActor>(ActorToSpawn, loc, roc);
+  // Uncomment the following line at a future date when difficulty settings are implemented
+  // ai->DifficultyParams.setParams(difficultySetting);
+  amountSpawned++;
+  return true;
+}
+
+FVector AAISpawner::GetSpawnLocation() {
+  FVector loc = GetActorLocation();
+  return loc;
 }
 
 
@@ -23,7 +35,7 @@ int AAISpawner::GetAmountOfAI() {
 void AAISpawner::BeginPlay()
 {
 	Super::BeginPlay();
-	GetWorldTimerManager().SetTimer(handler, this, &AAISpawner::AllowSpawning, 12.0f, false); // Begin spawning AI
+	//GetWorldTimerManager().SetTimer(handler, this, &AAISpawner::AllowSpawning, 12.0f, false); // Begin spawning AI
 }
 
 // Called every frame, will currently spawn AI (at the spawner location) based on the respawn timer interval until max have spawned. AI currently do not respawn
@@ -31,6 +43,7 @@ void AAISpawner::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 	
+	/*
 	respawnClock++;
 	if (respawnClock > respawnTimer && canSpawn && spawnEnabled && amountOfAI < maxAI)
 	{
@@ -43,6 +56,7 @@ void AAISpawner::Tick(float DeltaTime)
         amountOfAI++;
         respawnClock = 0;
 	}
+	*/
 }
 
 // Enable AI spawning

--- a/Source/BroncoDrome/StageActors/AISpawner.h
+++ b/Source/BroncoDrome/StageActors/AISpawner.h
@@ -19,7 +19,9 @@ public:
 
 	void AllowSpawning();
 
-	int GetAmountOfAI();
+	bool Spawn(FName difficultySetting);
+
+	FVector GetSpawnLocation();
 
 protected:
 	// Called when the game starts or when spawned
@@ -37,34 +39,14 @@ private:
 	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true")) 
         bool spawnEnabled = true; 
 
-	// How often to spawn new AI, until max AI is reached
+	// Can be disabled for debugging or difficulty
 	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true")) 
-        int respawnTimer= 200; 
+        bool onlySpawnOnce = false; 
 
-	// Maximum amount of AI actors this spawner can spawn
-	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true")) 
-        int maxAI = 1; 
-
-	// Difficulty of AI this spawner will spawn
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (GetOptions = "GetNameOptions", AllowPrivateAccess = "true")) 
-        FName difficultySetting = FName(TEXT("Medium"));  
-
-    UFUNCTION(CallInEditor)
-        TArray<FString> GetNameOptions() const {
-          return {TEXT("Easy"), TEXT("Medium"), TEXT("Hard")};
-        }
-
-	int amountOfAI = 0;
+	int amountSpawned = 0;
     int respawnClock = 0;
 
-	FTimerHandle SpawnerTimerHandler;
-
-	TArray<AAIActor*> aiActors;
-
-	int actorLocationIndex = 0;
-
 	bool canSpawn = false;
-    bool AISpawned = false;
 
 	FTimerHandle handler;
 };

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -11,25 +11,64 @@ AAISpawnerController::AAISpawnerController() : AActor() {
   PrimaryActorTick.bCanEverTick = true;
 }
 
-int AAISpawnerController::getMaxAI() { return maxAIs; }
-
 // Called when the game starts or when spawned
 void AAISpawnerController::BeginPlay() {
 	Super::BeginPlay();
 
 	// Finds all spawn points on the map and adds them to an array
-	TArray<AActor*> FoundActors;
-	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AAISpawner::StaticClass(), FoundActors);
+	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AAISpawner::StaticClass(), spawnPoints);
+    for (auto &Spwner : spawnPoints) {
+        numSpawnPoints++;
+	}
+	GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("NUMBER OF SPAWN POINTS: %d"), numSpawnPoints));
 
-	// For debugging purposes and example of access, below iterates through spawners to show how to access spawner functions
-	int numSpawners = 0;
-    for (auto &Spwner : FoundActors) {
-        numSpawners++;
-		GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("SPAWN POINT %d MAX AI: %d"), numSpawners, ((AAISpawner*)Spwner)->GetAmountOfAI()));
+	GetWorldTimerManager().SetTimer(handler, this, &AAISpawnerController::Init, 12.0f, false);  // Begin spawning AI after cutscene ends
+}
+
+void AAISpawnerController::Init() {
+	// Initially populate all spawners with an AI, if below maxAI threshold, on game start
+    for (auto &sp: spawnPoints) {
+		if (activeAI < maxAI) {
+            AAISpawnerController::AttemptSpawn(sp);
+		}
 	}
 
-	// Prints number of spawners for debugging purposes
-	GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("NUMBER OF SPAWN POINTS: %d"), numSpawners));
+	// Set spawnCheck interval. Will check if AI need to be respawned based on respawnCheckInSecs
+	GetWorldTimerManager().SetTimer(SpawnTimerHandler, this, &AAISpawnerController::SpawnCheck, respawnCheckInSecs, true);	
+}
+
+// Is called based on respawnCheckInSecs
+// TODO: Account for respawnRadius, maxRespawns, waveSpawning, dead AI
+void AAISpawnerController::SpawnCheck() {
+	GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Cyan, FString::Printf(TEXT("SPAWN CHECK, active AI: %d"), activeAI));
+	if (activeAI >= maxAI) return;
+	if (randomSpawning) { // Randomly spawns a single AI at a random spawn point
+		int randSpawnPoint = FMath::RandRange(0, (numSpawnPoints - 1));
+        int currSpawnPoint = 0;
+		for (auto &sp: spawnPoints) {
+            if (currSpawnPoint == randSpawnPoint) {
+			    AAISpawnerController::AttemptSpawn(sp);
+				GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Cyan, FString::Printf(TEXT("SPAWNED AI AT SPAWNER: %d"), currSpawnPoint));
+				return;
+            } else {
+			    currSpawnPoint++;
+		    }
+		}
+	} else {
+		for (auto &sp: spawnPoints) {
+			if (activeAI < maxAI) {
+                AAISpawnerController::AttemptSpawn(sp);
+			}
+		}
+	}
+
+}
+
+// Spawns an AI at the provided spawnPoint when called
+void AAISpawnerController::AttemptSpawn(AActor* spawnPoint) {
+    ((AAISpawner*)spawnPoint)->Spawn("Medium");
+    activeAI++;
+	totalSpawned++;
 }
 
 // Called every frame, will currently spawn AI (at the spawner location) based on the respawn timer interval until max have spawned. AI currently do not respawn

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -15,9 +15,6 @@ public:
 	AAISpawnerController();
     // Called every frame
     virtual void Tick(float DeltaTime) override;
-
-    int getMaxAI();
-
     // void decrementActiveAI(); TODO future function, will decrement activeAI and increment totalDead (will be called when AI runner is destroyed)
 
 
@@ -27,19 +24,31 @@ protected:
 
 
 private:
-
+    void Init();
+    void SpawnCheck();
+    void AttemptSpawn(AActor* spawnPoint);
+    // Total number of spawn points on this map
+    int numSpawnPoints = 0;
     // Number of AI currently in the game
     int activeAI = 0; 
     // Store total number of dead AI
     int totalDead = 0;
+    // Store total number of AI that have been spawned over the game's lifetime
+    int totalSpawned = 0;
+    // List of spawn points
+    TArray<AActor*> spawnPoints;
+    // Init Timer handler
+    FTimerHandle handler;
+    // Spawn timer handler
+    FTimerHandle SpawnTimerHandler;
 
     // Interval to check (in seconds) if an AI needs to be respawned
     UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true"))
-        int respawnCheckInSecs = 5;
+        float respawnCheckInSecs = 5.0f;
 
     // Maximum amount of AI actors that are allowed to be spawned on the map. This should typically be equal to or lower than the number of AISpawner points
     UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true"))
-        int maxAIs = 5; 
+        int maxAI = 5; 
 
     // The total number of times AI can be spawned in a given map (correlating to totalDead). This would likely only be relevant in a wave-type gamemode
     UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
References #162 

SpawnController now works in its simplest capacity and will find all spawn points and spawn AI at random spawn points based on basic configuration parameters. Presently with default settings, it will spawn one AI at each spawn point as long as max AI isn't reached, then will spawn one additional AI every 5 seconds at a random spawn point until max AI is reached. Does not currently keep track of if AI dies.