### PR TITLE
Update HUD health on heal

### DIFF
--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -575,7 +575,9 @@ void ARunner::AddToHealth(int newHealth) {
 				}, 1, false
 			);
 		}
-    } else if (!this->isAI) {
+    }
+	
+	if (!this->isAI) {
         HUD->SetHealth(health);
 	}
 }


### PR DESCRIPTION
References #167 
Simple logic error bug (that I introduced last sprint) that was preventing health bar from updating whenever the player was healed