### PR TITLE
66 reduce ai difficulty when player is losing

### DIFF
--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -582,6 +582,7 @@ void ARunner::AddToHealth(int newHealth) {
     }
 	
 	if (!this->isAI) {
+	  this->numDeaths ++; // increase the number of deaths
         HUD->SetHealth(health);
 	}
 }

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -582,7 +582,6 @@ void ARunner::AddToHealth(int newHealth) {
     }
 	
 	if (!this->isAI) {
-	  this->numDeaths ++; // increase the number of deaths
         HUD->SetHealth(health);
 	}
 }
@@ -607,7 +606,9 @@ void ARunner::Respawn() {
 	SetActorTickEnabled(true);
 	health = 100;	// Reset to full health
     HUD->SetHealth(health);
-	if (!this->isAI) HUD->SetDead(false);
+	if (!this->isAI) {
+	  HUD->SetDead(false);
+	}
 }
 
 void ARunner::AddToScore(int newScore) {

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -116,6 +116,7 @@ public: // Attributes
 	int playerDamage = 20; //Default damage
 	int gameTime = 180; //Time per level, in seconds
 	int AIToKill = 3;
+        int numDeaths = 0;
 	FTimerHandle GameTimeHandler; //For tick
 
 	//KillBall

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -116,7 +116,6 @@ public: // Attributes
 	int playerDamage = 20; //Default damage
 	int gameTime = 180; //Time per level, in seconds
 	int AIToKill = 3;
-        int numDeaths = 0;
 	FTimerHandle GameTimeHandler; //For tick
 
 	//KillBall

--- a/Source/BroncoDrome/SMainMenuWidget.cpp
+++ b/Source/BroncoDrome/SMainMenuWidget.cpp
@@ -8,7 +8,7 @@
 #include "MenuHUD.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
-#include <Runtime\Engine\Public\ImageUtils.h>
+//#include <Runtime\Engine\Public\ImageUtils.h>
 
 #define LOCTEXT_NAMESPACE "MainMenu"
 

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -76,8 +76,12 @@ void AAIActor::Tick(float DeltaTime)
 	if(!defensive)
           MoveTowardsPlayer(GetActorLocation(), FRotator(0.0f, 0.0f, 0.0f));
 
-        if (player_runner != NULL) { // runner may not have seen them, but when they do, difficulty will be updated
-          if(player_runner->numDeaths > 1 && !hasReduced) {
+        player_runner = ARunnerObserver::GetPlayer(*this, 38000.f, 180.f, true);
+
+
+        if (player_runner != NULL && !player_runner->isAI) { // runner may not have seen them, but when they do, difficulty will be updated
+          if(player_runner->lives == 1 && !hasReduced) {
+            //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("TESTY DESTY"), *GetDebugName(this)));
             hasReduced = true;
             DifficultyParams.decrementDifficulty();
             
@@ -186,6 +190,10 @@ void AAIActor::MoveDecision(FVector location) {
 
 	// auto player_location = GetWorld()->GetFirstPlayerController()->GetPawn()->GetActorLocation();
 	auto closest_runner = ARunnerObserver::GetClosestRunner(*this);
+        if (!closest_runner->isAI) {
+          player_runner = closest_runner;
+        }
+  
 	// auto closest_runner = ARunnerObserver::GetPlayer(*this);
 	auto player_location = closest_runner->GetActorLocation();
 	auto player_direction = GetWorld()->GetFirstPlayerController()->GetPawn()->GetActorRotation();

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -39,6 +39,7 @@ void AAIActor::BeginPlay()
 	Super::BeginPlay();
 	last_location = GetActorLocation();
 	NavSys = FNavigationSystem::GetCurrent<UNavigationSystemV1>(this);
+        DifficultyParams = FDifficultyParameters();
 }
 
 // Called every frame
@@ -74,8 +75,15 @@ void AAIActor::Tick(float DeltaTime)
 	// TODO: Remove if already handled in the Movement function
 	if(!defensive)
           MoveTowardsPlayer(GetActorLocation(), FRotator(0.0f, 0.0f, 0.0f));
-        
-  
+
+        if (player_runner != NULL) { // runner may not have seen them, but when they do, difficulty will be updated
+          if(player_runner->numDeaths > 1 && !hasReduced) {
+            hasReduced = true;
+            DifficultyParams.decrementDifficulty();
+            
+          }
+          
+        }
 }
 
 FHitResult* AAIActor::Raycast(FVector to)

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -8,7 +8,7 @@
 
 #include "DrawDebugHelpers.h"
 #include "AISpawner.h"
-
+#include "GameFramework/Character.h"
 
 
 // Sets default values
@@ -27,6 +27,7 @@ AAIActor::AAIActor() : ARunner()
 void AAIActor::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
+	
 
 	PlayerInputComponent->ClearActionBindings();
 	PlayerInputComponent->ClearBindingValues();
@@ -73,7 +74,8 @@ void AAIActor::Tick(float DeltaTime)
 	// TODO: Remove if already handled in the Movement function
 	if(!defensive)
           MoveTowardsPlayer(GetActorLocation(), FRotator(0.0f, 0.0f, 0.0f));
-
+        
+  
 }
 
 FHitResult* AAIActor::Raycast(FVector to)

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -34,7 +34,6 @@ struct FDifficultyParameters {
   // constructor
   FDifficultyParameters() {
     difficulty = FName(TEXT("Medium"));
-    
   }
   void decrementDifficulty() {
     damageMod = healthMod = fireRateMod -= 0.1;
@@ -54,15 +53,7 @@ struct FDifficultyParameters {
       damageMod = healthMod = fireRateMod = 0.8;
     }
   }
-
-  void checkForUpdates(AActor* actor) {
-    ARunner cur = (ARunner*) actor;
-    if(!current->isAI) {
-      if (current->numDeaths > 1) {
-        // update things
-      }
-    }
-  }
+  
 
   /*
    *get the difficulty modifier for ai damage 
@@ -140,7 +131,7 @@ public:
 	void ShotDecision(FVector location); //called in Tick to make a shot decision every 30 frames
 private:
 	float angleBetweenTwoVectors(FVector v1, FVector v2);
-        ARunner* current; 
+        bool hasReduced = false;
 	void Fire();
 	void drawTargetLine(FVector location);
 	void QueryLockOnEngage();

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -48,6 +48,9 @@ struct FDifficultyParameters {
     for (AActor* actor: FoundActors) {
       ARunner* current = (ARunner*) actor;
       if(!current->isAI) {
+        if (current->numDeaths > 0) {
+          // update things
+        }
         if (current->numDeaths > 1) {
           // update things
         }

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -12,10 +12,13 @@
 #include "../Runner/Runner.h"
 #include "../StageActors/RunnerObserver.h"
 #include "../StageActors/OrbProjectile.h"
-
+#include "Engine/World.h"
 #include "CoreMinimal.h"
+#include "AITestsCommon.h"
 #include "GameFramework/Actor.h"
 #include "AIActor.generated.h"
+
+
 
 /**
  * Struct to store and access difficulty parameters for AI actors
@@ -35,6 +38,22 @@ struct FDifficultyParameters {
   FDifficultyParameters() {
     difficulty = FName(TEXT("Medium"));
     
+  }
+
+  void updateDifficulty() {
+    // get all actors 
+    TArray<AActor*> FoundActors; 
+    UGameplayStatics::GetAllActorsOfClass(FAITestHelpers::GetWorld(), ARunner::StaticClass(), FoundActors);
+
+    for (AActor* actor: FoundActors) {
+      ARunner* current = (ARunner*) actor;
+      if(!current->isAI) {
+        if (current->numDeaths > 1) {
+          // update things
+        }
+      }
+    }
+
   }
 
   void setParams(FName diff) {

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -14,11 +14,8 @@
 #include "../StageActors/OrbProjectile.h"
 #include "Engine/World.h"
 #include "CoreMinimal.h"
-#include "AITestsCommon.h"
 #include "GameFramework/Actor.h"
 #include "AIActor.generated.h"
-
-
 
 /**
  * Struct to store and access difficulty parameters for AI actors
@@ -39,32 +36,9 @@ struct FDifficultyParameters {
     difficulty = FName(TEXT("Medium"));
     
   }
-
-
   void decrementDifficulty() {
     damageMod = healthMod = fireRateMod -= 0.1;
-
   }
-
-  void updateDifficulty() {
-    // get all actors 
-    TArray<AActor*> FoundActors; 
-    UGameplayStatics::GetAllActorsOfClass(FAITestHelpers::GetWorld(), ARunner::StaticClass(), FoundActors);
-
-    for (AActor* actor: FoundActors) {
-      ARunner* current = (ARunner*) actor;
-      if(!current->isAI) {
-        if (current->numDeaths > 0) {
-          decrementDifficulty();
-        }
-        if (current->numDeaths > 1) {
-          decrementDifficulty();
-        }
-      }
-    }
-
-  }
-
   void setParams(FName diff) {
     difficulty = diff;
     if(diff == TEXT("Easy")) {
@@ -78,6 +52,15 @@ struct FDifficultyParameters {
     }
     else { // this really shouldnt happen, but we'll just go with medium
       damageMod = healthMod = fireRateMod = 0.8;
+    }
+  }
+
+  void checkForUpdates(AActor* actor) {
+    ARunner cur = (ARunner*) actor;
+    if(!current->isAI) {
+      if (current->numDeaths > 1) {
+        // update things
+      }
     }
   }
 
@@ -157,6 +140,7 @@ public:
 	void ShotDecision(FVector location); //called in Tick to make a shot decision every 30 frames
 private:
 	float angleBetweenTwoVectors(FVector v1, FVector v2);
+        ARunner* current; 
 	void Fire();
 	void drawTargetLine(FVector location);
 	void QueryLockOnEngage();

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -40,6 +40,12 @@ struct FDifficultyParameters {
     
   }
 
+
+  void decrementDifficulty() {
+    damageMod = healthMod = fireRateMod -= 0.1;
+
+  }
+
   void updateDifficulty() {
     // get all actors 
     TArray<AActor*> FoundActors; 
@@ -49,10 +55,10 @@ struct FDifficultyParameters {
       ARunner* current = (ARunner*) actor;
       if(!current->isAI) {
         if (current->numDeaths > 0) {
-          // update things
+          decrementDifficulty();
         }
         if (current->numDeaths > 1) {
-          // update things
+          decrementDifficulty();
         }
       }
     }


### PR DESCRIPTION
Was having lots of issues with getting the player runner at a whim. My solution was to just wait until the ai runner sees the player runner. This way, the runner difficulty will only update when the see the player, this means that their shots, armor, etc.. will not scale down until then. I do not think this is a big issue. The advantage of this system is that it is very efficient compared to querying the world for the player runner. 