### PR TITLE
Fixed 0 lives left bug

### DIFF
--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -170,17 +170,17 @@ void ARunnerHUD::YouLose()
 {
 	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
 		load->score += m_Widgets->getScore();  //Update the score for the playthrough
-		class APlayerController* Mouse;
-		Mouse = world->GetFirstPlayerController();
-		paused = true;
-		//Reveals mouse and enables clicking
-		Mouse->bShowMouseCursor = true;
-		Mouse->bEnableClickEvents = true;
-		Mouse->bEnableMouseOverEvents = true;
 		m_LoseWidget->setScore(load->score); //Sets score to display on the lose screen
-		m_LoseWidget->AddToViewport(); //Displays the lose screen
-		UGameplayStatics::SetGamePaused(world, true); //Pauses Game
 	}
+	class APlayerController* Mouse;
+	Mouse = world->GetFirstPlayerController();
+	paused = true;
+	//Reveals mouse and enables clicking
+	Mouse->bShowMouseCursor = true;
+	Mouse->bEnableClickEvents = true;
+	Mouse->bEnableMouseOverEvents = true;
+	m_LoseWidget->AddToViewport(); //Displays the lose screen
+	UGameplayStatics::SetGamePaused(world, true); //Pauses Game
 }
 
 void ARunnerHUD::ShowPowerupWidget(FString powerupText) 

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -556,12 +556,13 @@ void ARunner::AddToHealth(int newHealth) {
 
 		/* If the player just died, they shouldn't be able to move until they respawn */
         DisableInput(GetWorld()->GetFirstPlayerController());
-
-        HUD->SetDead(true);
+        
 		if (lives <= 0) {
 			HUD->SetHealth(health);
 			LoseScreen();
 			return;
+		} else {
+            HUD->SetDead(true);
 		}
 														
 		/* This code will make it wait three second to respawn. Source: https://www.codegrepper.com/code-examples/cpp/unreal+engine+delay+c%2B%2B */

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -559,6 +559,7 @@ void ARunner::AddToHealth(int newHealth) {
 
         HUD->SetDead(true);
 		if (lives <= 0) {
+			HUD->SetHealth(health);
 			LoseScreen();
 			return;
 		}

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -542,18 +542,10 @@ void ARunner::AddToHealth(int newHealth) {
 		shotAbsorbOn = false;
 		shotAbsorbHits = 0;
 
-        HUD->SetDead(true);
-		lives--;
-		HUD->DecrementLivesLeft();
-		if (lives <= 0) {
-			LoseScreen();
-		}
-		FVector CurrentLocation = GetActorLocation();	// We want to keep track of where the runner was when it died
-
-		
 		/* This code will make it seem to disappear. Source: https://forums.unrealengine.com/t/disable-an-actor/4738/22 */
 
 		/* Stop its movement and teleport it up to prevent collisions first */
+		FVector CurrentLocation = GetActorLocation();	// We want to keep track of where the runner was when it died
 		Mover->Deactivate();
 		const FVector higher = { CurrentLocation.X, CurrentLocation.Y, CurrentLocation.Z + 100 };
 		const FRotator newOrientation = { 0, 0, 0 };
@@ -564,6 +556,12 @@ void ARunner::AddToHealth(int newHealth) {
 
 		/* If the player just died, they shouldn't be able to move until they respawn */
         DisableInput(GetWorld()->GetFirstPlayerController());
+
+        HUD->SetDead(true);
+		if (lives <= 0) {
+			LoseScreen();
+			return;
+		}
 														
 		/* This code will make it wait three second to respawn. Source: https://www.codegrepper.com/code-examples/cpp/unreal+engine+delay+c%2B%2B */
 		//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, FString::Printf(TEXT("Respawning in 3 seconds..."), *GetDebugName(this)));
@@ -619,6 +617,8 @@ void ARunner::Respawn() {
 	if (!this->isAI) {
 	  HUD->SetDead(false);
 	}
+    lives--;
+    HUD->DecrementLivesLeft();
 }
 
 void ARunner::AddToScore(int newScore) {


### PR DESCRIPTION
Closes #248 

There was a logic error in the health code and an issue with the lose widget being displayed. I changed the way lives are displayed so they only decrement and update the HUD when the player respawns. When they die when they have 0 lives left, then the game is lost. The respawn screen would also show when game is over, so I prevented that from showing too.

 Effectively, the lose widget would only be displayed if it could load the current game. For whatever reason, the save wasn't being initialized which may be something to look into more at a future date, but my guess is that the save is only initialized when the player launches a map from the menu instead of loading a level directly into the editor. In my fix, I still cause the game to be lost, but to perform load functions if possible. Thus, this bug was mostly only relevant to development, but nice to have fixed regardless.