### PR TITLE
252 test map fix

### DIFF
--- a/Content/Maps/BroncoDrome_TEST.umap
+++ b/Content/Maps/BroncoDrome_TEST.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2a1bfd577c78690acd1b8525131a6d072624eb94cbe3f7554135f7a460d0ace
-size 938766
+oid sha256:e85c4b935bd6e704b16dc762fba0f1dc25fda5d66d692a636d1aca1de42ff3d8
+size 939752


### PR DESCRIPTION
the changes to the spawning system broke something on the test map so that it would throw a compile error. This change fixes that. 