### PR TITLE
251 reaction time

### DIFF
--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -102,6 +102,11 @@ public:
 	int aiId;
 	int shot_rate = 90; //interval for AI shots //0=90; 1= 50; 2= 70;
 
+        // reaction time variables
+        int frameCounter = 0;
+        int reactionTime;
+        enum LastDecision { MoveToPlayer, MoveToSpawner };
+
 	bool defensive = false; // fighting / fleeing state variable
 
         FVector lastSeenPlayerLocation; // location of the last player as seen by raycast

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -105,7 +105,8 @@ public:
         // reaction time variables
         int frameCounter = 0;
         int reactionTime;
-        enum LastDecision { MoveToPlayer, MoveToSpawner };
+        enum Decisions { MoveToPlayer, MoveToSpawner };
+        int lastDecision = -1;
 
 	bool defensive = false; // fighting / fleeing state variable
 


### PR DESCRIPTION
runners will now take 4-12 frames to update to a new movement action. If the runner was previously moving towards the player and decides to move towards the player again on the newest frame, it can with no delay or penalty. However, if the runner was previously moving towards the player and wishes to move away or move towards a power up, there will be a random penalty between 4-12 frames. Also implemented the logic to choose to move towards a power up if there is no runner within a certain distance. There is no functionality to actually move towards a power up in place yet.