### PR TITLE
274 implement manual aiming

### DIFF
--- a/Content/Blueprints/UI/RunnerWidgets2.uasset
+++ b/Content/Blueprints/UI/RunnerWidgets2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1288a9191d4da9825cf73adf627160a0276a859b06ede3ed8ca94c321df87909
-size 241852
+oid sha256:9fa3c06bdd77b2cbc61c6683f038abfea2095806fdeb16b1f33b76ddb535d13d
+size 251172

--- a/Content/Blueprints/UI/RunnerWidgets2.uasset
+++ b/Content/Blueprints/UI/RunnerWidgets2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96dda6558531adcb984757d96405f52663d5577de9e42a254ece571a1e96dc36
-size 238549
+oid sha256:1288a9191d4da9825cf73adf627160a0276a859b06ede3ed8ca94c321df87909
+size 241852

--- a/Source/BroncoDrome/Runner/ARunnerHUD.h
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.h
@@ -84,6 +84,7 @@ public:		// Interface
 	inline void DecrementEnemiesLeft(void) { m_Widgets->DecrementEnemiesLeft(); DecrementAnemonies(); }
 	inline void SetGameTimeRemaining(int currentGameTime) {m_Widgets->SetGameTimeRemaining(currentGameTime);}
 	inline void RenderLockOnReticle(FVector worldSpace, bool hide) { m_Widgets->OnRenderLockOnReticle(worldSpace, hide); }
+	inline void SetAutoTarget(bool enabled) { m_Widgets->setAutoTarget(enabled); }
 
 public: 
 	void Pause();

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -317,7 +317,6 @@ void ARunner::CameraInput(float in)
 			AimBlaster(m_CameraTargetRunner->GetActorLocation(), GetWorld()->GetDeltaSeconds());
 		}
 	} else {
-		/*
 		class APlayerController* Mouse;
 		Mouse = GetWorld()->GetFirstPlayerController();
 		FVector AimLocation;
@@ -329,10 +328,10 @@ void ARunner::CameraInput(float in)
 			// Either soft-lock to a runner or aim forward (if GetClosestRunner() returns null)
 
 			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("%s"), *(AimLocation.ToString())));
+			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("%s"), *(AimDirection.ToString())));
 
 			AimBlaster(AimDirection, GetWorld()->GetDeltaSeconds());
 		}
-		*/
 	}
 }
 
@@ -420,6 +419,20 @@ void ARunner::Fire()
 	const auto rot = BlasterBase->GetComponentRotation();
 	const auto loc = BlasterBase->GetComponentLocation() + 200.0 * (rot.Vector());	//200 is to account for the length of the barrel
 
+	if (!isAI) {
+				class APlayerController* Mouse;
+		Mouse = GetWorld()->GetFirstPlayerController();
+		FVector AimLocation;
+		FVector AimDirection;
+		if (Mouse->DeprojectMousePositionToWorld(AimLocation, AimDirection)) {
+			GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("Actor Loc %s"), *(GetActorLocation().ToString())));
+			GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("Transformed blaster: %s"), *(loc.ToString())));
+			GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("Blaster: %s"), *(BlasterBase->GetComponentLocation().ToString())));
+			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("%s"), *(AimLocation.ToString())));
+			
+		}
+	}
+
 	//check for Kill Ball
 	if (killBallOn) {
 		ChangeMIntensity(2);
@@ -433,22 +446,8 @@ void ARunner::Fire()
 
 		if (projectile) {
 			//Projectile variables
-			if (!isAI) {
-				class APlayerController* Mouse;
-				Mouse = GetWorld()->GetFirstPlayerController();
-				FVector AimLocation;
-				FVector AimDirection;
-				if (Mouse->DeprojectMousePositionToWorld(AimLocation, AimDirection)) {
-					//GEngine->AddOnScreenDebugMessage(-1, 7.f, FColor::Cyan, FString::Printf(TEXT("got mouse pos %s"), *(AimDirection.ToString())));
-					projectile->FireOrbInDirection(AimDirection, this); //Damage is preset for KillBall
-				}
-				else {
-					projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
-				}
-			}
-			else {
-				projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
-			}
+			projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
+			
 			//Debug
 			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("You fired your KillBall weapon."), *GetDebugName(this)));
 			//Effects
@@ -465,22 +464,7 @@ void ARunner::Fire()
 		AOrbProjectile*  projectile = World->SpawnActor<AOrbProjectile>(ProjectileClass, loc, rot, SpawnParams); //Regular orb
 		if (projectile) {
 			//Projectile variables
-			if (!isAI) {
-				class APlayerController* Mouse;
-				Mouse = GetWorld()->GetFirstPlayerController();
-				FVector AimLocation;
-				FVector AimDirection;
-				if (Mouse->DeprojectMousePositionToWorld(AimLocation, AimDirection)) {
-					//GEngine->AddOnScreenDebugMessage(-1, 7.f, FColor::Cyan, FString::Printf(TEXT("got mouse pos %s"), *(AimDirection.ToString())));
-					projectile->FireOrbInDirection(AimDirection, this); //Damage is preset for KillBall
-				}
-				else {
-					projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
-				}
-			}
-			else {
-				projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
-			}
+			projectile->FireOrbInDirection(rot.Vector(), this); //Damage is preset for KillBall
 			projectile->shotDamage = playerDamage; //Set damage of shot to the players damage
 			//Debug
 			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("You fired your regular weapon."), *GetDebugName(this)));
@@ -536,8 +520,12 @@ void ARunner::AimBlaster(FVector targetLocation, const float deltaTime)
 	FRotator blasterSlerpedLookAt;
 
 	if (!isAI) {
+		//FVector correctedVector = ((GetActorLocation() + (targetLocation * 1000)) - (BlasterBase->GetComponentLocation() + 200.0 * (BlasterBase->GetComponentRotation().Vector()))).GetSafeNormal();
+		
+		//const FRotator blasterTargetLookAt = UKismetMathLibrary::FindLookAtRotation(
+		//	(BlasterBase->GetComponentLocation() + 200.0 * (BlasterBase->GetComponentRotation().Vector())), (BlasterBase->GetComponentLocation() + 200.0 * (BlasterBase->GetComponentRotation().Vector())) + correctedVector);'
 		const FRotator blasterTargetLookAt = UKismetMathLibrary::FindLookAtRotation(
-			BlasterBase->GetComponentLocation(), this->GetActorLocation() + (targetLocation * 1000));
+			BlasterBase->GetComponentLocation(), BlasterBase->GetComponentLocation() + targetLocation * 1000);
 		blasterSlerpedLookAt = UKismetMathLibrary::RLerp(BlasterBase->GetComponentRotation(),
 			blasterTargetLookAt, LOCK_ON_BLASTER_RPS * deltaTime, true);
 	}

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -689,7 +689,7 @@ void ARunner::Respawn() {
 	int currSpawnPoint = 0;
 	for (auto &sp : validSpawnPoints) {
 		if (currSpawnPoint == randSpawnPoint) {
-			FVector spawnHeightModifier = FVector(0.0f, 0.0f, 500.0f);
+			FVector spawnHeightModifier = FVector(0.0f, 0.0f, 300.0f);
 			TeleportTo(sp->GetActorLocation()+spawnHeightModifier, this->GetActorRotation());
 			Visible(true);
 			SetActorEnableCollision(true);

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -121,8 +121,13 @@ public: // Attributes
 	int AIToKill = 3;
 	FTimerHandle GameTimeHandler; //For tick
 	FTimerHandle ShotTimerHandler;
+	FTimerHandle AimTimerHandler;
 	bool canFire = true;
 	float shotTimerCooldown = 0.3f;
+	bool canAim = true;
+	float aimTimerCooldown = 0.05f;
+	FVector lastAimHitPoint;
+	bool autoTarget = false; // if the runner will automatically target instead of manual targeting
 
 	//KillBall
 	bool killBallOn;
@@ -205,6 +210,7 @@ public:
 	void CheckForGameOver();
 	void AddToScore(int newScore);  //Changes score
 	void SetCanFire();
+	void SetCanAim();
 
 	//Power ups
 	void hitMe(int damage); //Holds the needed steps to deal damage based on current powerups

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -120,6 +120,9 @@ public: // Attributes
 	int gameTime = 180; //Time per level, in seconds
 	int AIToKill = 3;
 	FTimerHandle GameTimeHandler; //For tick
+	FTimerHandle ShotTimerHandler;
+	bool canFire = true;
+	float shotTimerCooldown = 0.3f;
 
 	//KillBall
 	bool killBallOn;
@@ -201,6 +204,7 @@ public:
 	void DecrementAILeftToKill();
 	void CheckForGameOver();
 	void AddToScore(int newScore);  //Changes score
+	void SetCanFire();
 
 	//Power ups
 	void hitMe(int damage); //Holds the needed steps to deal damage based on current powerups
@@ -216,7 +220,7 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = ARunner)
 	void Visible(bool visible);
 
-	void AimBlaster(const class ARunner* targetRunner, const float deltaTime);
+	void AimBlaster(const FVector targetLocation, const float deltaTime);
 
 //Displays for winning and losing
 private:

--- a/Source/BroncoDrome/Runner/RunnerWidgets.cpp
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.cpp
@@ -57,3 +57,11 @@ int URunnerWidgets::getScore() {
 	playerScore += (gameTimeRemaining*10) + (livesLeft*100); // Factor in the time and lives remaining
 	return playerScore;
 }
+
+bool URunnerWidgets::getAutoTargetToggled() {
+	return autoTarget;
+}
+
+void URunnerWidgets::setAutoTarget(bool val) {
+	autoTarget = val;
+}

--- a/Source/BroncoDrome/Runner/RunnerWidgets.h
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.h
@@ -73,10 +73,16 @@ public:		// Interface
 	void SetEnemiesLeft(int newAmount);
 	void DecrementEnemiesLeft(void);
 
+	bool autoTarget = true;
+
 	int getAnemoniesLeft();
+	void setAutoTarget(bool val);
 
 	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable)
 	void OnRenderLockOnReticle(FVector worldSpace, bool hide);
+
+	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)
+	bool getAutoTargetToggled();
 
 	//Function to return the current player score
 	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -344,7 +344,7 @@ void AAIActor::drawTargetLine(FVector location) {
 
 		setTargetRunner = player_runner;
 
-		ARunner::AimBlaster(setTargetRunner, GetWorld()->GetDeltaSeconds());
+		ARunner::AimBlaster(setTargetRunner->GetActorLocation(), GetWorld()->GetDeltaSeconds());
 		LockOn();
 
 		if (shotCount < shot_rate) {  // shot timer (currently set to
@@ -361,7 +361,7 @@ void AAIActor::drawTargetLine(FVector location) {
 
 		setTargetRunner = aRunner;
 
-		ARunner::AimBlaster(setTargetRunner, GetWorld()->GetDeltaSeconds());
+		ARunner::AimBlaster(setTargetRunner->GetActorLocation(), GetWorld()->GetDeltaSeconds());
 		LockOn();
 
 		if (shotCount < shot_rate) {  // shot timer (currently set to

--- a/Source/BroncoDrome/StageActors/ParticleSpawner.cpp
+++ b/Source/BroncoDrome/StageActors/ParticleSpawner.cpp
@@ -46,9 +46,11 @@ APoolableObject* AParticleSpawner::SpawnParticle(ParticleType particle, const FV
 	switch (particle)
 	{
 	case ParticleType::Poof:
+		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("POOF particle spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan));
 		pool = SingletonInstance->PoofPool;
 		break;
 	case ParticleType::BigPoof:
+		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("BIG POOF spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan));
 		pool = SingletonInstance->BigPoofPool;
 		break;
 	default:


### PR DESCRIPTION
I have added everyone as a reviewer since this is a substantial change relevant to the entire team and feedback would be appreciated. **NOTE: run the game as a standalone/make sure the window size is 16:9 aspect ratio (no black bars) the accuracy of the aiming is affected due to the the reticle position is calculated relative to the UI widget which is preset at 16:9 aspect ratio.**

Closes Story #274 and tasks #275 #276 #277 and #278

By default, autoTarget is disabled until the UI setting for it is fully implemented. It can be manually enabled via changing the default value in runner.cpp.

In summary: This allows the player to control the blaster barrel of the runner with their mouse and prevents the player from spam shooting (you can only fire a configurable amount of shots per second). In addition, the targeting reticle now follows the mouse when autoTarget is disabled. The aiming is perfectly aligned with the reticle and dynamically adjusts the barrel based on obstacles to perfectly hit the location the mouse is on.

In the future, we could perhaps add a slight bullet spread (similar to how Damian did for the AI) so that there's some degree of variability in the shots like in typical FPS games, but we can discuss this. 