### PR TITLE
304 initialize game on cutscene skip

### DIFF
--- a/Content/Maps/Broncodrome_Day.umap
+++ b/Content/Maps/Broncodrome_Day.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e7f16fbbb71113c60e9c6a86852de2831c86ee72b8d8e9827bedad485cb6a19
-size 940654
+oid sha256:76d2cdabe051f4e5bdf835535434eb2572ba6daf105e5c7f828ece26e94968a2
+size 948223

--- a/Content/Maps/Broncodrome_Day.umap
+++ b/Content/Maps/Broncodrome_Day.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:818b03086deda252c1ba4017e21cce88a0c1f88f74e31e9427d618126a41adb4
-size 928129
+oid sha256:8af421c35b34daf48591c6e4c8e0a4a7a7c195c0b53635d186d9ff0062654ba5
+size 941948

--- a/Content/Maps/Broncodrome_Day.umap
+++ b/Content/Maps/Broncodrome_Day.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8af421c35b34daf48591c6e4c8e0a4a7a7c195c0b53635d186d9ff0062654ba5
-size 941948
+oid sha256:4e7f16fbbb71113c60e9c6a86852de2831c86ee72b8d8e9827bedad485cb6a19
+size 940654

--- a/Content/Maps/Broncodrome_Night.umap
+++ b/Content/Maps/Broncodrome_Night.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36a0346e30b09b3aa408f9ed09a5eb457484e227a20a7e5c91f480e43a4a4ef3
-size 886044
+oid sha256:7de6a0e5a51b459308ed227b5c99c02a2b2e17556b18737f9c166ab44b28ba41
+size 900116

--- a/Content/Maps/Broncodrome_Night.umap
+++ b/Content/Maps/Broncodrome_Night.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be600db39408bee3fe98611d67390066cc44ba359a2a883dced4a6a6bc46d880
-size 899921
+oid sha256:27c129af992bcf3a2323c78ea3298f5127b7e764c8dc3661716e232531d53154
+size 906259

--- a/Content/Maps/Broncodrome_Night.umap
+++ b/Content/Maps/Broncodrome_Night.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7de6a0e5a51b459308ed227b5c99c02a2b2e17556b18737f9c166ab44b28ba41
-size 900116
+oid sha256:be600db39408bee3fe98611d67390066cc44ba359a2a883dced4a6a6bc46d880
+size 899921

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -171,6 +171,12 @@ void ARunner::BeginPlay()
 	spawnController = ((AAISpawnerController*)UGameplayStatics::GetActorOfClass(GetWorld(), AAISpawnerController::StaticClass()));
 }
 
+// Called externally via a level's blueprint when a cutscene is skipped
+void ARunner::SkipCutscene() {
+	GetWorldTimerManager().ClearTimer(RunnerStatusHandler);
+	ReinstateAll();
+}
+
 void ARunner::ReinstateAll()
 {
 	Visible(true);

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -173,12 +173,16 @@ void ARunner::BeginPlay()
 
 // Called externally via a level's blueprint when a cutscene is skipped
 void ARunner::SkipCutscene() {
+	if (initialized) return;
 	GetWorldTimerManager().ClearTimer(RunnerStatusHandler);
 	ReinstateAll();
+	spawnController->SkipCutscene();
 }
 
 void ARunner::ReinstateAll()
 {
+	if (initialized) return;
+	initialized = true;
 	Visible(true);
 	EnableInput(GetWorld()->GetFirstPlayerController());
 	HUD->HideHUD(false);

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -128,6 +128,7 @@ public: // Attributes
 	float aimTimerCooldown = 0.05f;
 	FVector lastAimHitPoint;
 	bool autoTarget = false; // if the runner will automatically target instead of manual targeting
+	bool initialized = false; // if player is initialized
 
 	//KillBall
 	bool killBallOn;

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -200,6 +200,8 @@ private:
 	void QueryLockOnDisengage();
 	void Pause();
 	void FlashRed();
+	UFUNCTION(BlueprintCallable)
+	void SkipCutscene();
 	AAISpawnerController* spawnController;
 
 public:

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -27,14 +27,30 @@ void AAISpawnerController::BeginPlay() {
 }
 
 void AAISpawnerController::Init() {
+	if (initialized) return;
+	initialized = true;
 	// Spawn initial set of runners
-    AAISpawnerController::SpawnCheck();
+	if (waveSpawning) {
+		AAISpawnerController::SpawnCheck();
+	} else {
+		for (auto &sp: spawnPoints) {
+			if (activeAI < maxAI && totalSpawned < maxRespawns) {
+				AAISpawnerController::AttemptSpawn(sp);
+			}
+		}
+	}
 
 	// Initializes set of runners as well as gets the player runner and sets the player runner pointer
     AAISpawnerController::UpdateRunners();
 
 	// Set spawnCheck interval. Will check if AI need to be respawned based on respawnCheckInSecs
 	GetWorldTimerManager().SetTimer(SpawnTimerHandler, this, &AAISpawnerController::SpawnCheck, respawnCheckInSecs, true);	
+}
+
+void AAISpawnerController::SkipCutscene() {
+	if (initialized) return;
+	GetWorldTimerManager().ClearTimer(handler);
+	AAISpawnerController::Init();
 }
 
 // Is called based on respawnCheckInSecs

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -20,6 +20,7 @@ public:
     AActor* GetClosestRunnerToPoint(FVector);
     TArray<AActor*> GetValidSpawnPoints();
     int GetNumValidSpawnPoints();
+    void SkipCutscene();
 
 protected:
 	// Called when the game starts or when spawned
@@ -31,6 +32,7 @@ private:
     void SpawnCheck();
     void UpdateRunners();
     void AttemptSpawn(AActor* spawnPoint);
+    bool initialized = false;
     // Total number of spawn points on this map
     int numSpawnPoints = 0;
     // Number of AI currently in the game


### PR DESCRIPTION
Closes story #304 and tasks #305 and #306

Player and AI runners will now properly initialize and spawn on cutscene skip. I also added some additional spawn points to both maps and ensured all AI will spawn on initialization. 