### PR TITLE
Implement Game Difficulty

### DIFF
--- a/Source/BroncoDrome/BroncoSaveGame.cpp
+++ b/Source/BroncoDrome/BroncoSaveGame.cpp
@@ -14,4 +14,5 @@ UBroncoSaveGame::UBroncoSaveGame()
 	score = 0; //Represents the overall score
 	mapsBeaten = 0; //Represents how many maps have been beaten
 	SaveName = TEXT("curr"); //We set the save name here because there will only be 1 save game to keep track of the current playthrough
+	difficultySetting = FName(TEXT("Medium")); // Represents the game difficulty
 }

--- a/Source/BroncoDrome/BroncoSaveGame.h
+++ b/Source/BroncoDrome/BroncoSaveGame.h
@@ -21,7 +21,8 @@ public:
 		int mapsBeaten;
 	UPROPERTY(VisibleAnywhere, Category = Basic)
 		FString SaveName;
-
+	UPROPERTY(VisibleAnywhere, Category = Basic)
+		FName difficultySetting;  
 
 	UBroncoSaveGame();
 };

--- a/Source/BroncoDrome/SMainMenuWidget.cpp
+++ b/Source/BroncoDrome/SMainMenuWidget.cpp
@@ -59,7 +59,7 @@ void SMainMenuWidget::Construct(const FArguments &InArgs) {
   BuildMenu(OwningHUD->mainOrHScore);
 }
 
-void SMainMenuWidget::InitBroncoSave(int level) const {
+void SMainMenuWidget::InitBroncoSave(int level, FName difficulty) const {
   // Create and save the initial values. Nothing else is needed here "save" will
   // have the name "curr" for it's save slot.
   if (UBroncoSaveGame *save =
@@ -67,13 +67,14 @@ void SMainMenuWidget::InitBroncoSave(int level) const {
               UBroncoSaveGame::StaticClass()))) {
     save->score = 0;
     save->mapsBeaten = level;
+    save->difficultySetting = difficulty;
     UGameplayStatics::SaveGameToSlot(save, save->SaveName, 0);
   }
 }
 
-FReply SMainMenuWidget::OnPlayClicked() const {
+FReply SMainMenuWidget::OnPlayClicked(FName difficulty) const {
   if (OwningHUD.IsValid()) {
-    InitBroncoSave(-1);  // 0 will make it so that 3 levels will be played
+    InitBroncoSave(-1, difficulty);  // 0 will make it so that 3 levels will be played
     OwningHUD->RemoveMenu();
   }
 
@@ -84,7 +85,7 @@ FReply SMainMenuWidget::OnPlayClicked() const {
 
 FReply SMainMenuWidget::OnPlayDayClicked() const {
   if (OwningHUD.IsValid()) {
-    InitBroncoSave(3);  // 3 will make it so that only 1 level will be played
+    InitBroncoSave(3, "Medium");  // 3 will make it so that only 1 level will be played
     OwningHUD->RemoveMenu();
   }
 
@@ -95,7 +96,7 @@ FReply SMainMenuWidget::OnPlayDayClicked() const {
 
 FReply SMainMenuWidget::OnPlayNightClicked() const {
   if (OwningHUD.IsValid()) {
-    InitBroncoSave(3);  // 3 will make it so that only 1 level will be played
+    InitBroncoSave(3, "Medium");  // 3 will make it so that only 1 level will be played
     OwningHUD->RemoveMenu();
   }
 
@@ -106,7 +107,7 @@ FReply SMainMenuWidget::OnPlayNightClicked() const {
 
 FReply SMainMenuWidget::OnPlayRainClicked() const {
   if (OwningHUD.IsValid()) {
-    InitBroncoSave(3);  // 3 will make it so that only 1 level will be played
+    InitBroncoSave(3, "Medium");  // 3 will make it so that only 1 level will be played
     OwningHUD->RemoveMenu();
   }
 
@@ -585,7 +586,7 @@ void SMainMenuWidget::BuildMenu(int hOrM) {
                  [SNew(SHorizontalBox)
                      + SHorizontalBox::Slot().Padding(ButtonPadding)
                      [SNew(SButton)
-                        .OnClicked(this, &SMainMenuWidget::OnReturnToMainClicked)
+                        .OnClicked(this, &SMainMenuWidget::OnPlayClicked, FName(TEXT("Easy")))
                         .ButtonColorAndOpacity(FColor::Blue)
                          [SNew(SVerticalBox)
                           + SVerticalBox::Slot()
@@ -607,7 +608,7 @@ void SMainMenuWidget::BuildMenu(int hOrM) {
                     + SHorizontalBox::Slot().Padding(ButtonPadding)
                     //Medium Button
                     [SNew(SButton)
-                          .OnClicked(this, &SMainMenuWidget::OnReturnToMainClicked)
+                          .OnClicked(this, &SMainMenuWidget::OnPlayClicked, FName(TEXT("Medium")))
                           .ButtonColorAndOpacity(FColor::Blue)
                               [SNew(SVerticalBox) +
                                SVerticalBox::Slot()
@@ -629,7 +630,7 @@ void SMainMenuWidget::BuildMenu(int hOrM) {
                     +  SHorizontalBox::Slot().Padding(ButtonPadding)
                     //Hard Button
                     [SNew(SButton)
-                          .OnClicked(this, &SMainMenuWidget::OnReturnToMainClicked)
+                          .OnClicked(this, &SMainMenuWidget::OnPlayClicked, FName(TEXT("Hard")))
                           .ButtonColorAndOpacity(FColor::Blue)
                               [SNew(SVerticalBox) +
                                SVerticalBox::Slot()
@@ -717,7 +718,7 @@ void SMainMenuWidget::BuildMenu(int hOrM) {
                  // Play main game
                  + SVerticalBox::Slot().Padding(ButtonPadding)
                        [SNew(SButton)
-                            .OnClicked(this, &SMainMenuWidget::OnPlayClicked)
+                            .OnClicked(this, &SMainMenuWidget::OnPlayClicked, FName(TEXT("Medium")))
                             .ButtonColorAndOpacity(FColor::Blue)
                                 [SNew(STextBlock)
                                      .Font(ButtonTextStyle)

--- a/Source/BroncoDrome/SMainMenuWidget.h
+++ b/Source/BroncoDrome/SMainMenuWidget.h
@@ -25,8 +25,8 @@ public:
 
 	void Construct(const FArguments& InArgs);
 
-	void InitBroncoSave(int level) const; //helper method to initialize the save
-	FReply OnPlayClicked() const;
+	void InitBroncoSave(int level, FName difficulty) const; //helper method to initialize the save
+	FReply OnPlayClicked(FName difficulty) const;
 	FReply OnPlayDayClicked() const;
 	FReply OnPlayNightClicked() const;
 	FReply OnPlayRainClicked() const;

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -42,7 +42,16 @@ void AAIActor::BeginPlay()
 	NavSys = FNavigationSystem::GetCurrent<UNavigationSystemV1>(this);
   
     DifficultyParams = FDifficultyParameters();
+	UpdateDifficulty(FName(TEXT("Medium"))); // Set default difficulty to medium and update if necessary
     reactionTime = 6;
+
+
+
+}
+
+// Updates relevant difficulty settings for this runner
+void AAIActor::UpdateDifficulty(FName difficulty) {
+	DifficultyParams.setParams(difficulty);
 
 	// sets accuracyRange based on difficulty
 	// uses accuracyRange in Fire()
@@ -62,7 +71,6 @@ void AAIActor::BeginPlay()
 
 	  accuracyRange = FMath::FRandRange(0.000, 0.008);
     }
-
 }
 
 // Called every frame

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -28,7 +28,6 @@ AAIActor::AAIActor() : ARunner()
 void AAIActor::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
-	
 
 	PlayerInputComponent->ClearActionBindings();
 	PlayerInputComponent->ClearBindingValues();
@@ -42,35 +41,31 @@ void AAIActor::BeginPlay()
 	NavSys = FNavigationSystem::GetCurrent<UNavigationSystemV1>(this);
   
     DifficultyParams = FDifficultyParameters();
-	UpdateDifficulty(FName(TEXT("Medium"))); // Set default difficulty to medium and update if necessary
+	UpdateDifficulty(FName(TEXT("Medium"))); // Set default difficulty
     reactionTime = 6;
-
-
-
 }
 
 // Updates relevant difficulty settings for this runner
 void AAIActor::UpdateDifficulty(FName difficulty) {
 	DifficultyParams.setParams(difficulty);
 
-	// sets accuracyRange based on difficulty
-	// uses accuracyRange in Fire()
-	if(DifficultyParams.difficulty == TEXT("Easy")) {
+	accuracyRange = DifficultyParams.getDifficultyAccuracyRange();
+	playerDamage = 20 * DifficultyParams.getDifficultyDamageModifier();
+	health = 100 * DifficultyParams.getDifficultyHealthModifier();
+	shot_rate = 90 * DifficultyParams.getDifficultyFireRateModifier();
+}
 
-	  accuracyRange = FMath::FRandRange(0.000, 0.015);
+// Returns a vector to modify the shot angle based on difficulty
+FVector AAIActor::GetAccuracyVector() {
+	float accuracyRangeX, accuracyRangeY, accuracyRangeZ;
 
-    } else if(DifficultyParams.difficulty == TEXT("Medium")) {
+	accuracyRangeX = FMath::FRandRange(-accuracyRange, accuracyRange);
+	accuracyRangeY = FMath::FRandRange(-accuracyRange, accuracyRange);
+	accuracyRangeZ = FMath::FRandRange(-accuracyRange, accuracyRange);
+	
+	FVector accVec = FVector(accuracyRangeX, accuracyRangeY, accuracyRangeZ);
 
-	  accuracyRange = FMath::FRandRange(0.000, 0.008);
-
-    } else if(DifficultyParams.difficulty == TEXT("Hard")) {
-
-	  accuracyRange = FMath::FRandRange(0.000, 0.002);
-
-    } else { 
-
-	  accuracyRange = FMath::FRandRange(0.000, 0.008);
-    }
+	return accVec;
 }
 
 // Called every frame
@@ -406,7 +401,8 @@ void AAIActor::Fire() {
 		AOrbProjectile* Projectile = World->SpawnActor<AOrbProjectile>(AIProjectileClass, loc, rot, SpawnParams);
 		if (Projectile) {
 			PlaySound(laserAudioCue);
-			Projectile->FireOrbInDirection(rot.Vector()+accuracyRange, this);
+			Projectile->FireOrbInDirection(rot.Vector()+GetAccuracyVector(), this);
+			Projectile->shotDamage = playerDamage; //Set damage of shot to the runners damage
 		}
 		else {
 			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, FString::Printf(TEXT("Projectile init error"), *GetDebugName(this)));

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -27,30 +27,49 @@ struct FDifficultyParameters {
   UPROPERTY(EditAnywhere, BlueprintReadWrite)
   FName difficulty;
 
-  double damageMod;
-  double healthMod;
-  double fireRateMod;
+  float damageMod;
+  float healthMod;
+  float fireRateMod;
+  float accuracyRange;
 
   // constructor
   FDifficultyParameters() {
     difficulty = FName(TEXT("Medium"));
   }
   void decrementDifficulty() {
-    damageMod = healthMod = fireRateMod -= 0.1;
+	  damageMod -= 0.1;
+	  healthMod -= 0.1;
+	  fireRateMod += 0.1;
+	  accuracyRange += 0.01;
   }
   void setParams(FName diff) {
     difficulty = diff;
+	// default HP is 100
+	// default damage is 20
+	// default firerate is once every 90 ticks
+	// default accuracy is hard to describe, but makes most shots at close range and half or less shots at longer range
     if(diff == TEXT("Easy")) {
-      damageMod = healthMod = fireRateMod = 0.8;
+		healthMod = 0.8; // this will cause AI to die in 4 shots (80 hp)
+		damageMod = 0.5; // this will cause AI to deal half damage (10)
+        fireRateMod = 1.5; // this will cause AI to shoot 50% slower
+		accuracyRange = 0.05; // relatively bad accuracy
     }
     else if(diff == TEXT("Medium")) {
-      damageMod = healthMod = fireRateMod = 0.8;
+		healthMod = 1.0; // this will cause AI to die in 5 shots (default)
+		damageMod = 1.0; // this will cause AI to deal normal damage (20) (default)
+        fireRateMod = 1.0; // this will cause AI to shoot at normal shot speed
+		accuracyRange = 0.02; // decent accuracy
     }
     else if(diff == TEXT("Hard")) {
-      damageMod = healthMod = fireRateMod = 0.8;
+		healthMod = 1.2; // this will cause AI to die in 6 shots (120hp)
+		damageMod = 1.25; // this will cause AI to deal extra damage (25)
+        fireRateMod = 1.0; // this will cause AI to shoot at normal shot speed
+		accuracyRange = 0.005; // good accuracy
     }
     else { // this really shouldnt happen, but we'll just go with medium
-      damageMod = healthMod = fireRateMod = 0.8;
+		healthMod = 1.0;
+		damageMod = 1.0;
+        fireRateMod = 1.0;
     }
   }
   
@@ -58,18 +77,22 @@ struct FDifficultyParameters {
   /*
    *get the difficulty modifier for ai damage 
    */
-  double getDifficultyDamageModifier() {return damageMod;}
+  float getDifficultyDamageModifier() {return damageMod;}
 
   /*
  *get the difficulty modifier for ai health 
  */
-  double getDifficultyHealthModifier() {return healthMod;}
+  float getDifficultyHealthModifier() {return healthMod;}
 
   /*
   *get the difficulty modifier for ai fire rate 
   */
-  double getDifficultyFireRateModifier() {return fireRateMod;}
+  float getDifficultyFireRateModifier() {return fireRateMod;}
   
+  /*
+  *get the accuracy range for ai 
+  */
+  float getDifficultyAccuracyRange() {return accuracyRange;}
 };
 
 
@@ -145,6 +168,7 @@ private:
 	void QueryLockOnEngage();
 	void QueryLockOnDisengage();
 	void LockOn();
+	FVector GetAccuracyVector();
         
 };
 

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -136,6 +136,7 @@ public:
 	void MoveAwayFromPlayer(FVector player_location, FRotator player_direction);
 	void MoveTowardsPlayer(FVector player_location, FRotator player_direction);
 	void ShotDecision(FVector location); //called in Tick to make a shot decision every 30 frames
+	void UpdateDifficulty(FName difficulty);
 private:
 	float angleBetweenTwoVectors(FVector v1, FVector v2);
         bool hasReduced = false;

--- a/Source/BroncoDrome/StageActors/AISpawner.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawner.cpp
@@ -19,8 +19,6 @@ AActor* AAISpawner::Spawn(FName difficultySetting)
   FVector loc = GetActorLocation();
   FRotator roc = FRotator(0, 0, 0);
   AAIActor *ai = GetWorld()->SpawnActor<AAIActor>(ActorToSpawn, loc, roc);
-  // Uncomment the following line at a future date when difficulty settings are implemented
-  // ai->DifficultyParams.setParams(difficultySetting);
   amountSpawned++;
   return ai;
 }

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -2,8 +2,11 @@
 
 
 #include "AISpawner.h"
+#include "AIActor.h"
 #include "../Runner/Runner.h"
 #include "Math/Vector.h"
+#include "BroncoDrome/BroncoSaveGame.h"
+#include "GameFramework/GameUserSettings.h"
 
 // Sets default values
 AAISpawnerController::AAISpawnerController() : AActor() {
@@ -16,6 +19,8 @@ AAISpawnerController::AAISpawnerController() : AActor() {
 void AAISpawnerController::BeginPlay() {
 	Super::BeginPlay();
 
+	InitializeDifficulty(); 
+
 	// Finds all spawn points on the map and adds them to an array
 	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AAISpawner::StaticClass(), spawnPoints);
     for (auto &Spwner : spawnPoints) {
@@ -24,6 +29,14 @@ void AAISpawnerController::BeginPlay() {
 	//GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("NUMBER OF SPAWN POINTS: %d"), numSpawnPoints));
 
 	GetWorldTimerManager().SetTimer(handler, this, &AAISpawnerController::Init, 12.0f, false);  // Begin spawning AI after cutscene ends
+}
+
+// Overwrites the spawner controller difficulty with the saved difficulty selection from the menu
+// If for whatever reason there is no saved difficulty, difficulty will remain as set through the UProperties
+void AAISpawnerController::InitializeDifficulty(){
+	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
+		difficultySetting = load->difficultySetting;
+	}
 }
 
 void AAISpawnerController::Init() {
@@ -143,32 +156,31 @@ int AAISpawnerController::GetNumValidSpawnPoints() {
 
 // Spawns an AI at the provided spawnPoint when called
 void AAISpawnerController::AttemptSpawn(AActor* spawnPoint) {
-	AActor *newAI;
-    if (difficultySetting == "Random") {
-		int randDifficulty = FMath::RandRange(0, 2);
-		FName randDifficultyStr;
-		switch (randDifficulty) {
-			case 0:
-				randDifficultyStr = FName(TEXT("Easy"));
-				break;
-			case 1:
-                randDifficultyStr = FName(TEXT("Medium"));
-				break;
-			case 2:
-                randDifficultyStr = FName(TEXT("Hard"));
-				break;
-			default:
-				randDifficultyStr = FName(TEXT("Medium"));
-				break;
-		}
-		newAI = ((AAISpawner *)spawnPoint)->Spawn(randDifficultyStr);
-    } else {
-		newAI = ((AAISpawner *)spawnPoint)->Spawn(difficultySetting);
-	}
-    
+	AActor *newAI = ((AAISpawner *)spawnPoint)->Spawn(difficultySetting);    
 
 	if (IsValid(newAI)) {
 		runners.Add(newAI);
+		if (difficultySetting == "Random") {
+			int randDifficulty = FMath::RandRange(0, 2);
+			FName randDifficultyStr;
+			switch (randDifficulty) {
+				case 0:
+					randDifficultyStr = FName(TEXT("Easy"));
+					break;
+				case 1:
+					randDifficultyStr = FName(TEXT("Medium"));
+					break;
+				case 2:
+					randDifficultyStr = FName(TEXT("Hard"));
+					break;
+				default:
+					randDifficultyStr = FName(TEXT("Medium"));
+					break;
+			}
+			((AAIActor*)newAI)->UpdateDifficulty(randDifficultyStr);
+		} else {
+			((AAIActor*)newAI)->UpdateDifficulty(difficultySetting);
+		}
         activeAI++;
         totalSpawned++;
     } else {

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -30,6 +30,7 @@ private:
     void Init();
     void SpawnCheck();
     void UpdateRunners();
+    void InitializeDifficulty();
     void AttemptSpawn(AActor* spawnPoint);
     // Total number of spawn points on this map
     int numSpawnPoints = 0;


### PR DESCRIPTION
Closes story #308 and tasks #309 #310 #311

This fully implements difficulty into BroncoDrome. A player can select the difficulty from the main menu which will initialize a new game set at that difficulty. Spawned AI have a preset difficulty setting based off the AI spawner controller, but this will be overridden in the case a difficulty setting is found from the main menu.

difficulty actually modifies runner parameters now. Easy AI deal less damage to the player, have less health, shoot less often, and are less accurate. Medium is the former default. Hard deals increased damage, has more health, and is more accurate.