### PR TITLE
Point Runners Toward Center of Map on Spawn

### DIFF
--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -702,7 +702,8 @@ void ARunner::Respawn() {
 	for (auto &sp : validSpawnPoints) {
 		if (currSpawnPoint == randSpawnPoint) {
 			FVector spawnHeightModifier = FVector(0.0f, 0.0f, 300.0f);
-			TeleportTo(sp->GetActorLocation()+spawnHeightModifier, this->GetActorRotation());
+			FRotator rotator = UKismetMathLibrary::FindLookAtRotation(sp->GetActorLocation(),FVector(0.0f,0.0f,0.0f));
+			TeleportTo(sp->GetActorLocation()+spawnHeightModifier, rotator);
 			Visible(true);
 			SetActorEnableCollision(true);
 			SetActorTickEnabled(true);

--- a/Source/BroncoDrome/StageActors/AISpawner.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawner.cpp
@@ -4,6 +4,7 @@
 #include "AISpawner.h"
 #include "AIActor.h"
 #include "Math/Vector.h"
+#include "Kismet/KismetMathLibrary.h"
 
 // Sets default values
 AAISpawner::AAISpawner():AActor()
@@ -17,8 +18,8 @@ AActor* AAISpawner::Spawn(FName difficultySetting)
 {
   if ((onlySpawnOnce && amountSpawned > 0) || !spawnEnabled) return NULL;
   FVector loc = GetActorLocation();
-  FRotator roc = FRotator(0, 0, 0);
-  AAIActor *ai = GetWorld()->SpawnActor<AAIActor>(ActorToSpawn, loc, roc);
+  FRotator rotator = UKismetMathLibrary::FindLookAtRotation(this->GetActorLocation(),FVector(0.0f,0.0f,0.0f));
+  AAIActor *ai = GetWorld()->SpawnActor<AAIActor>(ActorToSpawn, loc, rotator);
   amountSpawned++;
   return ai;
 }


### PR DESCRIPTION
Closes #314

This will spawn players facing towards the center of the map on spawn/respawn (before, spawning was always set in the same direction which could result in facing a wall or corner).

Ideally, spawn rotator could be set by spawn point. I spent a good bit of time trying to get it to work but ran into some issues. It is not a priority and could be readdressed at a later time as this is an adequate fix in the meantime. 