### PR TITLE
Only Player Decrements Enemies Remaining

### DIFF
--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -606,7 +606,7 @@ void ARunner::LoseScreen() {
 	HUD->YouLose();
 }
 
-void ARunner::AddToHealth(int newHealth) {
+void ARunner::AddToHealth(int newHealth, bool damageOriginatedFromPlayer) {
 	health += newHealth;
 	if (newHealth < 0 && !(health <= 0)) {
 		PlaySound(runnerHitAudioCue);
@@ -614,21 +614,17 @@ void ARunner::AddToHealth(int newHealth) {
 	}
 	if (health >= 100) {
 		health = 100;
-	}
-	/* This is when a runner has lost all of its health */
-	else if (health <= 0) {
+	} else if (health <= 0) {
         health = 0;
 		PlaySound(runnerExplosionAudioCue);
         if (this->isAI) {  // If an AI just died, destroy the actor and move on, otherwise update player accordingly
-			HUD->DecrementEnemiesLeft();
+			if (damageOriginatedFromPlayer) { HUD->DecrementEnemiesLeft(); } // Only decrement enemies left if the kill is attributed to the player 
 			spawnController->DecrementActiveAI(this);
 			SpawnParticles();
 			Destroy();			
             return;
         }       
-        HUD->SetHealth(health);
-		lives--;
-    	HUD->DecrementLivesLeft();
+		HUD->SetHealth(health);
 		//KillBall PowerUp
 		killBallOn = false;
 		killBallShots = 0;
@@ -710,13 +706,13 @@ void ARunner::Respawn() {
 			health = 100;
 			HUD->SetHealth(health);
 			HUD->SetDead(false);
+    		HUD->DecrementLivesLeft();
+			lives--;
 			return;
 		} else {
 			currSpawnPoint++;
 		}
 	}
-    //lives--;
-    //HUD->DecrementLivesLeft();
 }
 
 void ARunner::AddToScore(int newScore) {
@@ -751,7 +747,7 @@ void ARunner::obstainKillBallPower(int hits) {
 
 //Orbs call this function when they hit the runner
 //Holds the needed steps to deal damage based on current powerups
-void ARunner::hitMe(int damage) {
+void ARunner::hitMe(int damage, AActor* shotOrigin) {
 	
 	//Powerups may change or negate the damage done to the runner
 
@@ -766,7 +762,14 @@ void ARunner::hitMe(int damage) {
 		}
 		PlaySound(spongeTinkAudioCue);
 	} else { //No power ups prevent the Shot from hitting runner
-		AddToHealth(damage); //Damage should be negative when passed into function
+		if (!((ARunner*)shotOrigin)->isAI) {
+			//GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("player projectile colliding with AI")));
+			AddToHealth(damage, true); //Damage should be negative when passed into function
+		}
+		else {
+			AddToHealth(damage, false); //Damage should be negative when passed into function
+		}
+		
 	}
 
 } 

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -762,7 +762,7 @@ void ARunner::hitMe(int damage, AActor* shotOrigin) {
 		}
 		PlaySound(spongeTinkAudioCue);
 	} else { //No power ups prevent the Shot from hitting runner
-		if (!((ARunner*)shotOrigin)->isAI) {
+		if (IsValid(shotOrigin) && !((ARunner*)shotOrigin)->isAI) {
 			//GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Cyan, FString::Printf(TEXT("player projectile colliding with AI")));
 			AddToHealth(damage, true); //Damage should be negative when passed into function
 		}

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -216,8 +216,8 @@ public:
 	void SetCanAim();
 
 	//Power ups
-	void hitMe(int damage); //Holds the needed steps to deal damage based on current powerups
-	void AddToHealth(int newHealth); //Changes health
+	void hitMe(int damage, AActor* shotOrigin); //Holds the needed steps to deal damage based on current powerups
+	void AddToHealth(int newHealth, bool damageOriginatedFromPlayer); //Changes health
 	void Respawn();	// For respawning
 	void AddToDamage(int addedDamage); //Can change damage
 	void obstainShotAbsorbPower(int hits); //ShotAbsorb 

--- a/Source/BroncoDrome/StageActors/OrbProjectile.cpp
+++ b/Source/BroncoDrome/StageActors/OrbProjectile.cpp
@@ -19,7 +19,8 @@ AOrbProjectile::AOrbProjectile()
 void AOrbProjectile::FireOrbInDirection(const FVector& Direction, AActor* Runner)
 {
 	UE_LOG(LogTemp, Display, TEXT("fire orb in direction: %s"), *(Direction.ToString()));
-	ProjectileMovementComponent->Velocity = Direction * ProjectileMovementComponent->InitialSpeed;
+	FVector heightMod = FVector(0.0f, 0.0f, 0.012f);
+	ProjectileMovementComponent->Velocity = (Direction + heightMod) * ProjectileMovementComponent->InitialSpeed;
 	RunnerParent = Runner; 
 }
 // Called when the game starts or when spawned

--- a/Source/BroncoDrome/StageActors/OrbProjectile.cpp
+++ b/Source/BroncoDrome/StageActors/OrbProjectile.cpp
@@ -18,7 +18,8 @@ AOrbProjectile::AOrbProjectile()
 }
 void AOrbProjectile::FireOrbInDirection(const FVector& Direction, AActor* Runner)
 {
-	ProjectileMovementComponent->Velocity = (Direction+0.012) * ProjectileMovementComponent->InitialSpeed;
+	UE_LOG(LogTemp, Display, TEXT("fire orb in direction: %s"), *(Direction.ToString()));
+	ProjectileMovementComponent->Velocity = Direction * ProjectileMovementComponent->InitialSpeed;
 	RunnerParent = Runner; 
 }
 // Called when the game starts or when spawned
@@ -41,7 +42,7 @@ void AOrbProjectile::OnHit(UPrimitiveComponent* HitComponent, AActor* OtherActor
 {
     if (OtherActor != this && OtherComponent->IsSimulatingPhysics()){
 		if (ARunner* runner = Cast<ARunner, AActor>(OtherActor)) {
-			runner->hitMe(shotDamage * (-1));//(Make it negative) //hitMe function lets runner deal with the powerups
+			runner->hitMe(shotDamage * (-1), RunnerParent);//(Make it negative) //hitMe function lets runner deal with the powerups
 			//runner->AddToHealth(shotDamage * (- 1)); //(Make it negative) Left here incase something breaks
 			//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Hit a runner."), *GetDebugName(this)));
 			Cast<ARunner, AActor>(RunnerParent)->AddToScore(10);

--- a/Source/BroncoDrome/StageActors/ParticleSpawner.cpp
+++ b/Source/BroncoDrome/StageActors/ParticleSpawner.cpp
@@ -46,11 +46,12 @@ APoolableObject* AParticleSpawner::SpawnParticle(ParticleType particle, const FV
 	switch (particle)
 	{
 	case ParticleType::Poof:
-		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("POOF particle spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan));
+
+		UE_LOG(LogTemp, Display, TEXT("POOF particle spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan);
 		pool = SingletonInstance->PoofPool;
 		break;
 	case ParticleType::BigPoof:
-		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("BIG POOF spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan));
+		UE_LOG(LogTemp, Display, TEXT("BIG POOF particle spawned at location: %s with velocity: %s and lifespan: %f"), *(worldLocation.ToString()), *(worldVelocity.ToString()), lifespan);
 		pool = SingletonInstance->BigPoofPool;
 		break;
 	default:
@@ -58,7 +59,6 @@ APoolableObject* AParticleSpawner::SpawnParticle(ParticleType particle, const FV
 		return nullptr;
 	}
 
-	GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Particle spawned")));
 	auto* object = pool->SpawnObject(worldLocation, worldVelocity, lifespan);
 	return object;
 }

--- a/Source/BroncoDrome/StageActors/PowerUp.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp.cpp
@@ -92,7 +92,7 @@ bool bFromSweep, const FHitResult& SweepResult)
 		switch (powerTypeIndex)
 		{
 			case 0:
-				dynamic_cast<ARunner*>(OtherActor)->AddToHealth(20); //Health
+				dynamic_cast<ARunner*>(OtherActor)->AddToHealth(20, false); //Health
 				//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Collected power Health"), *GetDebugName(this)));
 			break;
 			case 1:

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
@@ -112,7 +112,7 @@ void APowerUpMaster::ExecuteFunction(UPrimitiveComponent* OverlappedComp, AActor
 		//Add various calls to car methods in this switch statement to accomplish power up stuff.
 		switch (powerTypeIndex) {
 			case 0:
-				dynamic_cast<ARunner*>(OtherActor)->AddToHealth(20); //Health
+				dynamic_cast<ARunner*>(OtherActor)->AddToHealth(20, false); //Health
 				dynamic_cast<ARunner*>(OtherActor)->PlaySound(healthAudioCue);
 				GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Collected power Health"), *GetDebugName(this)));
 				selectedPowerUp = FString("HEALTH");


### PR DESCRIPTION
Closes #316

This checks who shot a projectile when colliding with another runner, thus if the player shot the projectile and the projectile kills a runner, THEN it decrements the enemies remaining instead of enemies decrementing no matter how a runner was killed.

Also changed a couple debugging messages to show up in the log instead of on screen for better error tracing and a cleaner display.