### PR TITLE
399 fix speed powerup

### DIFF
--- a/Content/Blueprints/Runners/RunnerGoKart.uasset
+++ b/Content/Blueprints/Runners/RunnerGoKart.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fa54a090169604c5875f3ce5a3d7037d5fd5218bf2a62747416ee2f5faf5dcc
-size 212952
+oid sha256:b36acfa4ecfc0780d3e91bf0e7abbfd3cdb05c30a3e67700ef5092d31d564c04
+size 209879

--- a/Content/Blueprints/Runners/RunnerGoKartExternalCurve.uasset
+++ b/Content/Blueprints/Runners/RunnerGoKartExternalCurve.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aba1bf83032a375f15251e273fd01709f6c8a2d2cdde6ca762f0098eaeb0985d
+oid sha256:621554892891848263f2c08d737ee76d4da9cb34295dba843b1e20c2d02d6494
 size 2002

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -273,19 +273,18 @@ void ARunner::ThrottleInput(float in)
 	}
 	Mover->SetTargetGear(targetGear, true);
 	Mover->SetBrakeInput(0.f);
-	Mover->SetThrottleInput(in); // throttle input is limited in range -1.0 to 1.0, any value above or below is clipped to the maximum
 
 	const float speed = Mover->GetForwardSpeedMPH();
 	if (speedBoost && UKismetMathLibrary::Abs(speed) > maxSpeedWithBoost) {
 		Mover->SetThrottleInput(0.f);
 	} else if (!speedBoost && UKismetMathLibrary::Abs(speed) > maxSpeed) {
 		Mover->SetThrottleInput(0.f);
+	} else {
+		Mover->SetThrottleInput(in); // throttle input is limited in range -1.0 to 1.0, any value above or below is clipped to the maximum
 	}
 
 	// Set engine audio param to Mover's
 	engineAudioComponent->SetFloatParameter(FName("EnginePower"), Mover->GetEngineRotationSpeed() / Mover->GetEngineMaxRotationSpeed());
-
-	//if (!isAI) GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("Input: %1.1f"), in));
 }
 
 // Enables a speed boost (uncaps throttle) this happens when a speed powerup is picked up and lasts for duration

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -272,16 +272,20 @@ void ARunner::ThrottleInput(float in)
 		if (!speedBoost) in = -defaultSpeed; 
 	}
 	Mover->SetTargetGear(targetGear, true);
+	Mover->SetBrakeInput(0.f);
 
 	// If current speed sign is opposite of target gear, apply brakes
-	const float speed = Mover->GetForwardSpeed();
-	if ((targetGear == 1 && speed < 0.f) || (targetGear == -1 && speed > 0.f))
-		Mover->SetBrakeInput(in);
+	const float speed = Mover->GetForwardSpeedMPH();
+	if (UKismetMathLibrary::Abs(speed) > 0.5f) {
+		if ((targetGear == 1 && speed < -0.1f) || (targetGear == -1 && speed > 0.1f)) {
+			Mover->SetBrakeInput(in);
+		}
+	}
 
 	// Set engine audio param to Mover's
 	engineAudioComponent->SetFloatParameter(FName("EnginePower"), Mover->GetEngineRotationSpeed() / Mover->GetEngineMaxRotationSpeed());
 
-	if (!isAI) GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("Input: %1.1f"), in));
+	//if (!isAI) GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Blue, FString::Printf(TEXT("Input: %1.1f"), in));
 	// Finally, set throttle input
 	Mover->SetThrottleInput(in); // throttle input is limited in range -1.0 to 1.0, any value above or below is clipped to the maximum
 }

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -227,7 +227,9 @@ public:
 	void DisableSpeedBoost();
 	bool speedBoost = false;
 	FTimerHandle SpeedBoostTimerHandler;
-	float defaultSpeed = 0.2f; // This is the default throttle input (60%) when not under effect of speed boost powerup (max speed is 1.0 or 100% of throttle input) this must be less than 1.0 so that the speed power up will work
+	float defaultThrottle = 0.3f; // This is the default throttle input (30%) when not under effect of speed boost powerup (max throttle is 1.0 or 100% of throttle input)
+	float maxSpeed = 30.f; // speed in mph
+	float maxSpeedWithBoost = 45.f; // speed in mph with speed boost active
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = ARunner)
 	void SpawnParticles();

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -223,6 +223,11 @@ public:
 	void AddToDamage(int addedDamage); //Can change damage
 	void obstainShotAbsorbPower(int hits); //ShotAbsorb 
 	void obstainKillBallPower(int shots); //KillBall
+	void EnableSpeedBoost(float duration); // speed boost
+	void DisableSpeedBoost();
+	bool speedBoost = false;
+	FTimerHandle SpeedBoostTimerHandler;
+	float defaultSpeed = 0.7f; // This is the default throttle input (60%) when not under effect of speed boost powerup (max speed is 1.0 or 100% of throttle input) this must be less than 1.0 so that the speed power up will work
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = ARunner)
 	void SpawnParticles();

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -227,7 +227,7 @@ public:
 	void DisableSpeedBoost();
 	bool speedBoost = false;
 	FTimerHandle SpeedBoostTimerHandler;
-	float defaultSpeed = 0.7f; // This is the default throttle input (60%) when not under effect of speed boost powerup (max speed is 1.0 or 100% of throttle input) this must be less than 1.0 so that the speed power up will work
+	float defaultSpeed = 0.2f; // This is the default throttle input (60%) when not under effect of speed boost powerup (max speed is 1.0 or 100% of throttle input) this must be less than 1.0 so that the speed power up will work
 
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = ARunner)
 	void SpawnParticles();

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -201,6 +201,7 @@ private:
 	void QueryLockOnEngage();
 	void QueryLockOnDisengage();
 	void Pause();
+	bool paused = false;
 	void FlashRed();
 	UFUNCTION(BlueprintCallable)
 	void SkipCutscene();

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
@@ -118,7 +118,7 @@ void APowerUpMaster::ExecuteFunction(UPrimitiveComponent* OverlappedComp, AActor
 				selectedPowerUp = FString("HEALTH");
 				break;
 			case 1:
-				dynamic_cast<ARunner*>(OtherActor)->ThrottleInput(5.0f); //Speed Which doesn't work and I don't know how to fix it
+				dynamic_cast<ARunner*>(OtherActor)->EnableSpeedBoost(10.0f); // Enable speed boost for 10 seconds
                 dynamic_cast<ARunner*>(OtherActor)->PlaySound(speedAudioCue);
 				GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("Collected power Speed"), *GetDebugName(this)));
 				selectedPowerUp = FString("SPEED");


### PR DESCRIPTION
Icky icky.

Closes #399 

This changes the way throttle is handled on the player. Now, the player has an artificial throttle limit that is uncapped when they have a speed boost. They also have a set max speed with and without the speed boost (the runner has a higher torque and top speed overall, but the throttle is cut when the max speed is reached, the way the torque curve and everything works this was the best solution I could come up with). Overall, it finally works now as expected and the speed boost works well too! Presently does not work for AI though, but that is not as necessary.

I did a lot of tweaking and made care to make sure the speed and acceleration still feels comparable prior to my changes. This should make future runners more configurable too as we can adjust max speed properties or even adjust the acceleration.