### PR TITLE
369 implement survival gamemode

### DIFF
--- a/Content/Blueprints/UI/LoseWidget.uasset
+++ b/Content/Blueprints/UI/LoseWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed12ff3de2d92ec2cb613769cbff86131f9d68cb995ef8c0d28dde0080e7ec2b
-size 118535
+oid sha256:60e49e50338f9afa4ebe54124c15b6077308858208445d24e466d47d4156d1f8
+size 147733

--- a/Content/Blueprints/UI/RunnerWidgets2.uasset
+++ b/Content/Blueprints/UI/RunnerWidgets2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa3c06bdd77b2cbc61c6683f038abfea2095806fdeb16b1f33b76ddb535d13d
-size 251172
+oid sha256:6dd491e7383fcd0b274e905f2875a5780e5af5eb52386061a9a156b995be5bab
+size 271722

--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -250,8 +250,11 @@ void ARunnerHUD::YouLose()
 	}
 	if (save->gamemodeSelection == TEXT("Survival")) {
 		m_LoseWidget->setWave(m_Widgets->getWave());
+		save->score = m_Widgets->getScoreLoss();  //Update the score for the playthrough
 	}
-	save->score += m_Widgets->getScore();  //Update the score for the playthrough
+	else {
+		save->score += m_Widgets->getScoreLoss();  //Update the score for the playthrough
+	}
 	m_LoseWidget->setScore(save->score); //Sets score to display on the lose screen
 	class APlayerController* Mouse;
 	Mouse = world->GetFirstPlayerController();

--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -242,6 +242,9 @@ void ARunnerHUD::YouLose()
         Practice();
 		return;
 	}
+	if (save->gamemodeSelection == TEXT("Survival")) {
+		m_LoseWidget->setWave(m_Widgets->getWave());
+	}
 	save->score += m_Widgets->getScore();  //Update the score for the playthrough
 	m_LoseWidget->setScore(save->score); //Sets score to display on the lose screen
 	class APlayerController* Mouse;

--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -2,7 +2,6 @@
 
 
 #include "ARunnerHUD.h"
-#include "BroncoDrome/BroncoSaveGame.h"
 #include "Sound/SoundCue.h"
 
 #include "GameFramework/GameUserSettings.h"
@@ -102,6 +101,27 @@ void ARunnerHUD::BeginPlay()
 	{
 		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Could not find TSubclassOf<UUserWidget>"));
     }
+
+
+	if (save = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) { // Check if a gamemode save is initialized
+		validSave = true;
+	}
+	else {
+		UE_LOG(LogTemp, Error, TEXT("Gamemode save not initialized"));
+		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Gamemode save not initialized"));
+	}
+
+	// Connect the spawner controller to keep track of runner deaths
+	spawnController = ((AAISpawnerController*)UGameplayStatics::GetActorOfClass(GetWorld(), AAISpawnerController::StaticClass()));
+	if (spawnController) {
+		if (validSave && save->gamemodeSelection == TEXT("Survival")) {
+			spawnController->EnableWaveSpawning();
+		}
+	}
+	else {
+		UE_LOG(LogTemp, Error, TEXT("Could not connect to AI Spawner Controller"));
+		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Could not connect to AI Spawner Controller"));
+	}
 }
 
 void ARunnerHUD::DrawHUD()
@@ -156,7 +176,12 @@ void ARunnerHUD::SetAnemonies(int anemonies) {
 
 void ARunnerHUD::DecrementAnemonies() {
 	anemoniesLeft--;
-	if (anemoniesLeft == 0) YouWin();
+	if (anemoniesLeft == 0 && save->gamemodeSelection != TEXT("Survival")) {
+		YouWin();
+	}
+	else {
+		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Spawn new wave"));
+	}
 }
 
 int ARunnerHUD::getLives() {
@@ -170,43 +195,39 @@ int ARunnerHUD::getEnemiesLeft() {
 void ARunnerHUD::YouWin(){
 	//Need to see how many maps have been beaten
 	int mapsBeat = 0;
-	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
-		if (load->gamemodeSelection == TEXT("Freeplay")) {
-            Practice();
-			return;
-		}
-		mapsBeat = load->mapsBeaten;
-		load->score += m_Widgets->getScore();  //Update the score for the playthrough
-		load->mapsBeaten++;
-		if (UGameplayStatics::SaveGameToSlot(load, load->SaveName, 0)) { //this saves the load object
-			//SHOULD display win widget, is causing an error
-			class APlayerController* Mouse;
-			Mouse = world->GetFirstPlayerController();
-			paused = true;
-			//Reveals mouse and enables clicking
-			Mouse->bShowMouseCursor = true;
-			Mouse->bEnableClickEvents = true;
-			Mouse->bEnableMouseOverEvents = true;
-			m_WinWidget->setScore(load->score); //Sets score for adding to the high scores tab
-			m_WinWidget->AddToViewport(); //Displays the win screen
-			m_WinWidget->PlayFadeInAnimation();
-			//Pauses Game
-			HideHUD(true);
-			UGameplayStatics::SetGamePaused(world, true);
-		}
+	if (save->gamemodeSelection == TEXT("Freeplay")) {
+        Practice();
+		return;
+	}
+	mapsBeat = save->mapsBeaten;
+	save->score += m_Widgets->getScore();  //Update the score for the playthrough
+	save->mapsBeaten++;
+	if (UGameplayStatics::SaveGameToSlot(save, save->SaveName, 0)) { //this saves the load object
+		//SHOULD display win widget, is causing an error
+		class APlayerController* Mouse;
+		Mouse = world->GetFirstPlayerController();
+		paused = true;
+		//Reveals mouse and enables clicking
+		Mouse->bShowMouseCursor = true;
+		Mouse->bEnableClickEvents = true;
+		Mouse->bEnableMouseOverEvents = true;
+		m_WinWidget->setScore(save->score); //Sets score for adding to the high scores tab
+		m_WinWidget->AddToViewport(); //Displays the win screen
+		m_WinWidget->PlayFadeInAnimation();
+		//Pauses Game
+		HideHUD(true);
+		UGameplayStatics::SetGamePaused(world, true);
 	}
 }
 
 void ARunnerHUD::YouLose() 
 {
-	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
-		if (load->gamemodeSelection == TEXT("Freeplay")) {
-            Practice();
-			return;
-		}
-		load->score += m_Widgets->getScore();  //Update the score for the playthrough
-		m_LoseWidget->setScore(load->score); //Sets score to display on the lose screen
+	if (save->gamemodeSelection == TEXT("Freeplay")) {
+        Practice();
+		return;
 	}
+	save->score += m_Widgets->getScore();  //Update the score for the playthrough
+	m_LoseWidget->setScore(save->score); //Sets score to display on the lose screen
 	class APlayerController* Mouse;
 	Mouse = world->GetFirstPlayerController();
 	paused = true;

--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -170,6 +170,20 @@ void ARunnerHUD::Pause() {
 	
 }
 
+void ARunnerHUD::InitializeEnemiesLeft() {
+	if (save->gamemodeSelection == TEXT("Survival")) {
+		SetEnemiesLeft(spawnController->GetWaveSize());
+	} else {
+		if (save->difficultySetting == TEXT("Easy")) {
+			SetEnemiesLeft(4);
+		} else if (save->difficultySetting == TEXT("Medium")) {
+			SetEnemiesLeft(6);
+		} else {
+			SetEnemiesLeft(8);
+		}
+	}
+}
+
 void ARunnerHUD::SetAnemonies(int anemonies) {
 	anemoniesLeft = anemonies;
 }
@@ -179,8 +193,10 @@ void ARunnerHUD::DecrementAnemonies() {
 	if (anemoniesLeft == 0 && save->gamemodeSelection != TEXT("Survival")) {
 		YouWin();
 	}
-	else {
+	else if (anemoniesLeft == 0) {
 		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Spawn new wave"));
+		SetEnemiesLeft(spawnController->GetWaveSize());
+		m_Widgets->IncrementCurrentWave();
 	}
 }
 

--- a/Source/BroncoDrome/Runner/ARunnerHUD.cpp
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.cpp
@@ -3,6 +3,7 @@
 
 #include "ARunnerHUD.h"
 #include "Sound/SoundCue.h"
+#include "Runner.h"
 
 #include "GameFramework/GameUserSettings.h"
 
@@ -170,6 +171,10 @@ void ARunnerHUD::Pause() {
 	
 }
 
+bool ARunnerHUD::IsSurvivalMode() {
+	return save->gamemodeSelection == TEXT("Survival");
+}
+
 void ARunnerHUD::InitializeEnemiesLeft() {
 	if (save->gamemodeSelection == TEXT("Survival")) {
 		SetEnemiesLeft(spawnController->GetWaveSize());
@@ -197,6 +202,7 @@ void ARunnerHUD::DecrementAnemonies() {
 		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, TEXT("Spawn new wave"));
 		SetEnemiesLeft(spawnController->GetWaveSize());
 		m_Widgets->IncrementCurrentWave();
+		// ((ARunner*)spawnController->GetPlayer())->IncrementGameTime(m_Widgets->getWave() * 10); // optional feature to add additional scaling time to the clock based on the current wave
 	}
 }
 

--- a/Source/BroncoDrome/Runner/ARunnerHUD.h
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.h
@@ -120,5 +120,6 @@ public:
 	void DecrementAnemonies();
 	int getLives();
 	int getEnemiesLeft();
+	bool IsSurvivalMode();
 	void ShowPowerupWidget(FString powerupText);
 };

--- a/Source/BroncoDrome/Runner/ARunnerHUD.h
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.h
@@ -106,6 +106,7 @@ public:		// Interface
 	inline void SetGameTimeRemaining(int currentGameTime) {m_Widgets->SetGameTimeRemaining(currentGameTime);}
 	inline void RenderLockOnReticle(FVector worldSpace, bool hide) { m_Widgets->OnRenderLockOnReticle(worldSpace, hide); }
 	inline void SetAutoTarget(bool enabled) { m_Widgets->setAutoTarget(enabled); }
+	void InitializeEnemiesLeft();
 
 public: 
 	void Pause();

--- a/Source/BroncoDrome/Runner/ARunnerHUD.h
+++ b/Source/BroncoDrome/Runner/ARunnerHUD.h
@@ -13,6 +13,7 @@
 #include "../StageActors/PowerUp/PowerupWidget.h"
 #include "Kismet/GameplayStatics.h"
 #include "../BroncoSaveGame.h"
+#include "../StageActors/AISpawnerController.h"
 #include "ARunnerHUD.generated.h"
 
 /**
@@ -87,6 +88,8 @@ private:	// Members
 	UPROPERTY()
 		UBroncoSaveGame *save;
 
+	bool validSave = false;
+	AAISpawnerController* spawnController;
 		
 
 public:		// Interface

--- a/Source/BroncoDrome/Runner/LoseWidget.cpp
+++ b/Source/BroncoDrome/Runner/LoseWidget.cpp
@@ -1,5 +1,6 @@
 // // Copyright (C) Team Gregg 2022. All Rights Reserved.
-
+#include "BroncoDrome/BroncoSaveGame.h"
+#include "Kismet/GameplayStatics.h"
 #include "LoseWidget.h"
 
 void ULoseWidget::NativePreConstruct()
@@ -13,6 +14,12 @@ void ULoseWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
+	// Check if survival mode is active (to update HUD)
+	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
+		if (load->gamemodeSelection == TEXT("Survival")) {
+			survivalMode = true;
+		}
+	}
 }
 
 void ULoseWidget::hScoreSubmit(FText initials) 
@@ -92,6 +99,11 @@ void ULoseWidget::hScoreSubmit(FText initials)
 void ULoseWidget::setScore(int score) 
 {
 	pscore = score;
+}
+
+void ULoseWidget::setWave(int wave) 
+{
+	pwave = wave;
 }
 
 void ULoseWidget::showHScore(UVerticalBox* scoreBox, UTextBlock* pleaseText, UTextBlock* totalScore) 

--- a/Source/BroncoDrome/Runner/LoseWidget.h
+++ b/Source/BroncoDrome/Runner/LoseWidget.h
@@ -20,6 +20,10 @@ public:		// Constructors
 	//player score
 	UPROPERTY(BlueprintReadOnly)
 		int pscore = 0;
+	UPROPERTY(BlueprintReadOnly)
+		int pwave = 0;
+	UPROPERTY(BlueprintReadOnly)
+		bool survivalMode = false;
 	//Array for scores
 	UPROPERTY()
 		TArray<FString> Result;
@@ -28,6 +32,7 @@ public:		// Constructors
 		UVerticalBox* sBox;
 	UPROPERTY()
 		UTextBlock* pText;
+
 
 protected:	// Overrides
 
@@ -43,6 +48,9 @@ public:		// Interface
 	//Function to set the current players score
 	UFUNCTION(BlueprintCallable, Category = UWinWidget)
 		void setScore(int score);
+
+	UFUNCTION(BlueprintCallable, Category = UWinWidget)
+		void setWave(int wave);
 
 	UFUNCTION(BlueprintCallable, Category = UWinWidget)
 		void showHScore(UVerticalBox* scoreBox, UTextBlock* pleaseText, UTextBlock* totalScore);

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -188,6 +188,22 @@ void ARunner::ReinstateAll()
 	HUD->HideHUD(false);
 	HUD->SetAutoTarget(autoTarget);
 
+	if (save = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) { // Check if a gamemode save is initialized
+		if (save->gamemodeSelection == TEXT("Survival")) {
+			gameTime = 120; // change allotted game time to 120 secs instead of default (180) this is because the player adds time to the clock for each kill they get
+			HUD->SetGameTimeRemaining(gameTime);
+
+			// Change amount of time that is added to the clock on runner kills
+			if (save->difficultySetting == TEXT("Easy")) {
+				timeAddedOnKill = 3;
+			} else if (save->difficultySetting == TEXT("Medium")) {
+				timeAddedOnKill = 4;
+			} else {
+				timeAddedOnKill = 5;
+			}
+		}
+	}
+
 	//Commence game timer
 	GetWorld()->GetTimerManager().SetTimer(
 		GameTimeHandler, this, &ARunner::DecrementGameTime, 1, false);
@@ -239,6 +255,12 @@ void ARunner::DecrementGameTime()
 	HUD->SetGameTimeRemaining(gameTime);
 
 	gameTime >= 1 ? GetWorld()->GetTimerManager().SetTimer(GameTimeHandler, this, &ARunner::DecrementGameTime, 1, false) : LoseScreen();
+}
+
+void ARunner::IncrementGameTime()
+{
+	gameTime += timeAddedOnKill;
+	HUD->SetGameTimeRemaining(gameTime);
 }
 
 void ARunner::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
@@ -653,7 +675,12 @@ void ARunner::AddToHealth(int newHealth, bool damageOriginatedFromPlayer) {
         health = 0;
 		PlaySound(runnerExplosionAudioCue);
         if (this->isAI) {  // If an AI just died, destroy the actor and move on, otherwise update player accordingly
-			if (damageOriginatedFromPlayer) { HUD->DecrementEnemiesLeft(); } // Only decrement enemies left if the kill is attributed to the player 
+			if (damageOriginatedFromPlayer) { 
+				HUD->DecrementEnemiesLeft(); // Only decrement enemies left if the kill is attributed to the player 
+				if (HUD->IsSurvivalMode()) { // Add time to the timer on a kill if playing survival mode
+					((ARunner*)spawnController->GetPlayer())->IncrementGameTime();
+				}
+			} 
 			spawnController->DecrementActiveAI(this);
 			SpawnParticles();
 			Destroy();			

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -677,6 +677,7 @@ void ARunner::AddToHealth(int newHealth, bool damageOriginatedFromPlayer) {
         if (this->isAI) {  // If an AI just died, destroy the actor and move on, otherwise update player accordingly
 			if (damageOriginatedFromPlayer) { 
 				HUD->DecrementEnemiesLeft(); // Only decrement enemies left if the kill is attributed to the player 
+				HUD->AddToScore(50); // add to player score on kill
 				if (HUD->IsSurvivalMode()) { // Add time to the timer on a kill if playing survival mode
 					((ARunner*)spawnController->GetPlayer())->IncrementGameTime();
 				}

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -811,7 +811,12 @@ void ARunner::hitMe(int damage, AActor* shotOrigin) {
 			AddToHealth(damage, true); //Damage should be negative when passed into function
 		}
 		else {
-			AddToHealth(damage, false); //Damage should be negative when passed into function
+			if (!this->isAI) { // If shot is from an AI and hitting the player
+				AddToHealth(damage, false);
+			}
+			else if (((ARunner*)shotOrigin)->friendlyFire) { // Check if the AI is allowed to deal damage to other AI
+				AddToHealth(damage, false);
+			}
 		}
 		
 	}

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -146,7 +146,7 @@ void ARunner::BeginPlay()
 		DisableInput(GetWorld()->GetFirstPlayerController());
 		HUD = Cast<ARunnerHUD>(GetWorld()->GetFirstPlayerController()->GetHUD());
 		HUD->HideHUD(true);
-		HUD->SetEnemiesLeft(3);
+		HUD->InitializeEnemiesLeft();
 		GetWorldTimerManager().SetTimer(RunnerStatusHandler, this, &ARunner::ReinstateAll, 12.0f, false);
 		InitStateMachines();
 		// Begin looping engine audio

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -118,6 +118,7 @@ public: // Attributes
 	int lives = 3;	// out of 3
 	int playerDamage = 20; //Default damage
 	int gameTime = 180; //Time per level, in seconds
+	int timeAddedOnKill = 7; // this only applies in survival mode
 	int AIToKill = 3;
 	FTimerHandle GameTimeHandler; //For tick
 	FTimerHandle ShotTimerHandler;
@@ -207,11 +208,14 @@ private:
 	UFUNCTION(BlueprintCallable)
 	void SkipCutscene();
 	AAISpawnerController* spawnController;
+	UPROPERTY()
+		UBroncoSaveGame *save;
 
 public:
 	bool IsGrounded();
 	void FixRotation();
 	void DecrementGameTime();
+	void IncrementGameTime();
 	void DecrementAILeftToKill();
 	void CheckForGameOver();
 	void AddToScore(int newScore);  //Changes score

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -139,6 +139,7 @@ public: // Attributes
 	int shotAbsorbHits;
 	//Designate Player-AI
 	bool isAI = false;
+	bool friendlyFire = false; // if friendly fire is on (if AI can damage/target other AI)
 	FTimerHandle RunnerStatusHandler;
 
 private:

--- a/Source/BroncoDrome/Runner/RunnerWidgets.cpp
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.cpp
@@ -1,6 +1,8 @@
 // // Copyright (C) Dromies 2021. All Rights Reserved.
 
 #include "RunnerWidgets.h"
+#include "BroncoDrome/BroncoSaveGame.h"
+#include "Kismet/GameplayStatics.h"
 
 void URunnerWidgets::NativePreConstruct()
 {
@@ -14,6 +16,14 @@ void URunnerWidgets::NativeConstruct()
 	Super::NativeConstruct();
 
 	playerScore = 0; 
+
+	// Check if survival mode is active (to update HUD)
+	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
+		if (load->gamemodeSelection == TEXT("Survival")) {
+			survivalMode = true;
+			currentWave = 1;
+		}
+	}
 }
 
 void URunnerWidgets::increaseScoreVar(int score) {
@@ -38,6 +48,10 @@ void URunnerWidgets::SetSpeed(float newSpeed) {
 
 void URunnerWidgets::SetGameTimeRemaining(int newTime){
 	gameTimeRemaining = newTime;
+}
+
+void URunnerWidgets::IncrementCurrentWave() {
+	currentWave++;
 }
 
 void URunnerWidgets::DecrementLivesLeft() {

--- a/Source/BroncoDrome/Runner/RunnerWidgets.cpp
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.cpp
@@ -88,7 +88,7 @@ int URunnerWidgets::getScore() {
 //Calculate the player score on a loss (specifically, ignore game time remaining)
 int URunnerWidgets::getScoreLoss() {
 	if (survivalMode) {
-		playerScore *= (difficultyScoreModifier * 10.f); // Give boost since player always has no time and/or lives remaining on survival loss
+		playerScore *= (difficultyScoreModifier * 3.f); // Give boost since player always has no time and/or lives remaining on survival loss
 	}
 	else {
 		playerScore *= difficultyScoreModifier; // Factor in the difficulty modifier

--- a/Source/BroncoDrome/Runner/RunnerWidgets.cpp
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.cpp
@@ -72,6 +72,11 @@ int URunnerWidgets::getScore() {
 	return playerScore;
 }
 
+//Return the current wave the player has reached (in survival mode)
+int URunnerWidgets::getWave() {
+	return currentWave;
+}
+
 bool URunnerWidgets::getAutoTargetToggled() {
 	return autoTarget;
 }

--- a/Source/BroncoDrome/Runner/RunnerWidgets.cpp
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.cpp
@@ -23,6 +23,13 @@ void URunnerWidgets::NativeConstruct()
 			survivalMode = true;
 			currentWave = 1;
 		}
+		if (load->difficultySetting == TEXT("Easy")) {
+			difficultyScoreModifier = 0.5f;
+		} else if (load->difficultySetting == TEXT("Medium")) {
+			difficultyScoreModifier = 1.f;
+		} else {
+			difficultyScoreModifier = 1.5f;
+		}
 	}
 }
 
@@ -66,9 +73,27 @@ void URunnerWidgets::DecrementEnemiesLeft(void) {
 	enemiesLeft--;
 }
 
-//Return the current player score
+//Return the player score on a win
 int URunnerWidgets::getScore() {
-	playerScore += (gameTimeRemaining*10) + (livesLeft*100); // Factor in the time and lives remaining
+	if (survivalMode) {
+		playerScore *= (difficultyScoreModifier * 10.f); // Give boost since player always has no time and/or lives remaining on survival loss
+	}
+	else {
+		playerScore += ((gameTimeRemaining*10) + (livesLeft*100)) * difficultyScoreModifier; // Factor in the time and lives remaining and difficulty
+	}
+	
+	return playerScore;
+}
+
+//Calculate the player score on a loss (specifically, ignore game time remaining)
+int URunnerWidgets::getScoreLoss() {
+	if (survivalMode) {
+		playerScore *= (difficultyScoreModifier * 10.f); // Give boost since player always has no time and/or lives remaining on survival loss
+	}
+	else {
+		playerScore *= difficultyScoreModifier; // Factor in the difficulty modifier
+	}
+	
 	return playerScore;
 }
 

--- a/Source/BroncoDrome/Runner/RunnerWidgets.h
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.h
@@ -57,7 +57,7 @@ protected:	// Overrides
 
 private:	// Members
 
-
+	float difficultyScoreModifier = 1;
 
 public:		// Interface
 
@@ -95,6 +95,10 @@ public:		// Interface
 	//Function to return the current player score
 	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)
 		int getScore();
+
+	//Function to return the current player score
+	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)
+		int getScoreLoss();
 
 	//Function to return the current player score
 	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)

--- a/Source/BroncoDrome/Runner/RunnerWidgets.h
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.h
@@ -96,4 +96,7 @@ public:		// Interface
 	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)
 		int getScore();
 
+	//Function to return the current player score
+	UFUNCTION(BlueprintCallable, Category = URunnerWidgets)
+		int getWave();
 };

--- a/Source/BroncoDrome/Runner/RunnerWidgets.h
+++ b/Source/BroncoDrome/Runner/RunnerWidgets.h
@@ -20,7 +20,13 @@ public:		// Constructors
 	// UUserWidget does not have a constructor :(
 	// Instead, NativePreConstruct() and NativeConstruct() overrides to init variables
 	UPROPERTY(BlueprintReadOnly)
-	int playerScore = 0; 
+	int playerScore = 0;
+
+	UPROPERTY(BlueprintReadOnly)
+	int currentWave = 0;
+
+	UPROPERTY(BlueprintReadOnly)
+	bool survivalMode = false;
 
 	UPROPERTY(BlueprintReadOnly)
 	float healthFloat = 1.0; 
@@ -72,6 +78,8 @@ public:		// Interface
 
 	void SetEnemiesLeft(int newAmount);
 	void DecrementEnemiesLeft(void);
+
+	void IncrementCurrentWave(void); 
 
 	bool autoTarget = true;
 

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -43,6 +43,15 @@ void AAIActor::BeginPlay()
     DifficultyParams = FDifficultyParameters();
 	UpdateDifficulty(FName(TEXT("Medium"))); // Set default difficulty
     reactionTime = 6;
+
+	if (UBroncoSaveGame* load = Cast<UBroncoSaveGame>(UGameplayStatics::LoadGameFromSlot("curr", 0))) {
+		if (load->gamemodeSelection == TEXT("Survival")) {
+			friendlyFire = false;
+		}
+		else {
+			friendlyFire = true;
+		}
+	}
 }
 
 // Updates relevant difficulty settings for this runner
@@ -360,7 +369,7 @@ void AAIActor::drawTargetLine(FVector location) {
 		Fire();
 
 	}
-	else if (aRunner) {
+	else if (aRunner && friendlyFire) {
 
 		setTargetRunner = aRunner;
 

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -83,22 +83,22 @@ int AAISpawnerController::GetWaveSize() {
 void AAISpawnerController::SpawnCheck() {
 	//GEngine->AddOnScreenDebugMessage(-1, 10.f, FColor::Cyan, FString::Printf(TEXT("SPAWN CHECK, active AI: %d"), activeAI));
 	if (totalSpawned >= maxRespawns) return;
-	if (waveSpawning) {
-        if (activeAI == 0 || waveSpawningInProgress) {
-            if (!waveSpawningInProgress) {
-				waveSize += waveIncrement;
+	if (waveSpawning) { // Check if wave spawning is enabled
+        if (activeAI == 0 || waveSpawningInProgress) { // Wave spawning will spawn AI in complete waves. No more AI will spawn once they reach the wave size limit, until the entire wave is destroyed, then a new wave spawns and the process restarts.
+            if (!waveSpawningInProgress) { // Check if this is first iteration of wave spawning
 				waveSpawningInProgress = true;
 				GEngine->AddOnScreenDebugMessage(-1, 7.f, FColor::Cyan, FString::Printf(TEXT("New wave spawning...")));
 				GEngine->AddOnScreenDebugMessage(-1, 7.f, FColor::Cyan, FString::Printf(TEXT("Wave Size: %d"), waveSize));
 			}
 			
 			for (auto &sp : spawnPoints) {
-				if (totalSpawned < maxRespawns && currentWaveAmountSpawned < waveSize) {
+				if (totalSpawned < maxRespawns && currentWaveAmountSpawned < waveSize) { // Keep spawning AI until wave size is reached
 					AAISpawnerController::AttemptSpawn(sp);
 					currentWaveAmountSpawned++;
-				} else {
+				} else { // Wave spawning is complete, reset variables and increment next wave size
                     waveSpawningInProgress = false;
 					currentWaveAmountSpawned = 0;
+					waveSize += waveIncrement;
 					break;
 				}
 			}

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -68,6 +68,17 @@ void AAISpawnerController::SkipCutscene() {
 
 void AAISpawnerController::EnableWaveSpawning() {
 	waveSpawning = true;
+
+	if (difficultySetting == TEXT("Easy")) {
+		waveSize = 3;
+		waveIncrement = 1;
+	} else if (difficultySetting == TEXT("Medium")) {
+		waveSize = 4;
+		waveIncrement = 2;
+	} else {
+		waveSize = 5;
+		waveIncrement = 3;
+	}
 }
 
 int AAISpawnerController::GetActiveAI() {
@@ -93,8 +104,7 @@ void AAISpawnerController::SpawnCheck() {
 			
 			for (auto &sp : spawnPoints) {
 				if (totalSpawned < maxRespawns && currentWaveAmountSpawned < waveSize) { // Keep spawning AI until wave size is reached
-					AAISpawnerController::AttemptSpawn(sp);
-					currentWaveAmountSpawned++;
+					if (AAISpawnerController::AttemptSpawn(sp))	currentWaveAmountSpawned++;
 				} else { // Wave spawning is complete, reset variables and increment next wave size
                     waveSpawningInProgress = false;
 					currentWaveAmountSpawned = 0;
@@ -183,7 +193,7 @@ int AAISpawnerController::GetNumValidSpawnPoints() {
 }
 
 // Spawns an AI at the provided spawnPoint when called
-void AAISpawnerController::AttemptSpawn(AActor* spawnPoint) {
+bool AAISpawnerController::AttemptSpawn(AActor* spawnPoint) {
 	AActor *newAI = ((AAISpawner *)spawnPoint)->Spawn(difficultySetting);    
 
 	if (IsValid(newAI)) {
@@ -211,8 +221,9 @@ void AAISpawnerController::AttemptSpawn(AActor* spawnPoint) {
 		}
         activeAI++;
         totalSpawned++;
+		return true;
     } else {
-        //spawnPoints.Remove(spawnPoint);
+		return false;
 	}
 }
 

--- a/Source/BroncoDrome/StageActors/AISpawnerController.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.cpp
@@ -66,6 +66,18 @@ void AAISpawnerController::SkipCutscene() {
 	AAISpawnerController::Init();
 }
 
+void AAISpawnerController::EnableWaveSpawning() {
+	waveSpawning = true;
+}
+
+int AAISpawnerController::GetActiveAI() {
+	return activeAI;
+}
+
+int AAISpawnerController::GetWaveSize() {
+	return waveSize;
+}
+
 // Is called based on respawnCheckInSecs
 // TODO: Account for waveSpawning
 void AAISpawnerController::SpawnCheck() {

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -35,7 +35,7 @@ private:
     void SpawnCheck();
     void UpdateRunners();
     void InitializeDifficulty();
-    void AttemptSpawn(AActor* spawnPoint);
+    bool AttemptSpawn(AActor* spawnPoint);
     bool initialized = false;
     // Total number of spawn points on this map
     int numSpawnPoints = 0;

--- a/Source/BroncoDrome/StageActors/AISpawnerController.h
+++ b/Source/BroncoDrome/StageActors/AISpawnerController.h
@@ -21,6 +21,9 @@ public:
     TArray<AActor*> GetValidSpawnPoints();
     int GetNumValidSpawnPoints();
     void SkipCutscene();
+    void EnableWaveSpawning();
+    int GetActiveAI();
+    int GetWaveSize();
 
 protected:
 	// Called when the game starts or when spawned


### PR DESCRIPTION
Fully implements the survival gamemode into BroncoDrome. 

Closes story #369 and tasks #394 #395 #396 #397 #317 and #318

It is possible to select a "Survival" gamemode now. In this gamemode, the game does not end until you run out of time or run out of lives. Enemies will keep spawning in progressively larger waves. Difficulty was kept in mind so on easy, waves are smaller whereas on hard they get bigger faster. Each successful runner kill allots additional time to the game clock. In addition, AI runners will only target and can only damage the player runner in this mode.