### PR TITLE
update runner selection screenshots

### DIFF
--- a/Content/Assets/Screenshots/RunnerBalanced.uasset
+++ b/Content/Assets/Screenshots/RunnerBalanced.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5df376cb5a7306ce22c7eb2efb4e0b66840253f121e7cb1409888725dc892c8
+size 481340

--- a/Content/Assets/Screenshots/RunnerSpeed.uasset
+++ b/Content/Assets/Screenshots/RunnerSpeed.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2dedf5f43c0cfb555f0d8987a95c5d239d373eaea227347fe4550e09026da4c
+size 825423

--- a/Content/Assets/Screenshots/RunnerTraction.uasset
+++ b/Content/Assets/Screenshots/RunnerTraction.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79c107b541395bd1baeed054a4bae106e39a5fe9e851af4e84c404df388c580b
+size 795675

--- a/Content/Assets/Screenshots/temprunnerbalanced.uasset
+++ b/Content/Assets/Screenshots/temprunnerbalanced.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af73abb8dc16a4251ee300544ab871a3348d813d22f158e83fb4a1d1112c1721
-size 436792

--- a/Content/Assets/Screenshots/temprunnercontrol.uasset
+++ b/Content/Assets/Screenshots/temprunnercontrol.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:095a383073a4bb2d7addffe3ed499829d62dc6c8f0fb954e33de7fd36937a2de
-size 499451

--- a/Content/Assets/Screenshots/temprunnerspeed.uasset
+++ b/Content/Assets/Screenshots/temprunnerspeed.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed281219061a79c13158e8da14d66597a3db7cdb5fbe5aa94070789bce542538
-size 619304

--- a/Content/Blueprints/UI/GamemodeSelectWidget.uasset
+++ b/Content/Blueprints/UI/GamemodeSelectWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11848f69a0334901c941b08ba67b65de6bf21f2cb5ed2ccb308a3ad14ae0a612
-size 925374
+oid sha256:5a292a038a9e7cc044ca48ab1079e9110b4c842729bd377a44e5893904c4d6fa
+size 905706


### PR DESCRIPTION
Closes #423 

Removed the old temporary images and replaced them with standardized screenshots of the new models.