### PR TITLE
Movement

### DIFF
--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -9,6 +9,8 @@
 #include "DrawDebugHelpers.h"
 #include "AISpawner.h"
 #include "GameFramework/Character.h"
+#include "PowerUp.h"
+
 #include "Math/RandomStream.h"
 
 
@@ -270,10 +272,7 @@ void AAIActor::MoveDecision(FVector location) {
             
             // there are no nearby runners, should try to move towards 
             if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 5000) {
-              //TODO another nested if to check if there is a nearby power up, which is still a pain to do
-              // get closest power up
-              
-              GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners,"), *GetDebugName(this)));
+              MoveTowardsPowerUp(powerup_location);
               lastDecision = 1;
               reactionTime = FMath::RandRange(4,12);
             }

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -236,59 +236,65 @@ void AAIActor::MoveDecision(FVector location) {
 
   //this vector may be coming from the center of objects, which is why runners used to continuously run into objects
   if (!dir.Equals(FVector(0.0f, 0.0f, 0.0f))) {
-
     if (dir.Equals(FVector::ForwardVector)) {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
       Mover->SetSteeringInput(-1.0f);
       ThrottleInput(-1.0f);
     }
     else if (dir.Equals(FVector::LeftVector)) {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward"), *GetDebugName(this)));
       Mover->SetSteeringInput(1.0f);
       ThrottleInput(1.0f);
     }
     else if (dir.Equals(FVector::RightVector)) {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward"), *GetDebugName(this)));
       Mover->SetSteeringInput(-1.0f);
       ThrottleInput(1.0f);
     }
     else if (dir.Equals((FVector::LeftVector + FVector::ForwardVector))) {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward reverse"), *GetDebugName(this)));
       Mover->SetSteeringInput(1.0f);
       ThrottleInput(-1.0f);
     }
     else if (dir.Equals((FVector::RightVector + FVector::ForwardVector))) {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward reverse"), *GetDebugName(this)));
       Mover->SetSteeringInput(-1.0f);
       ThrottleInput(-1.0f);
     }
   }
 
           
-          if (frameCounter >= reactionTime && player_runner != NULL){
-          // there are no nearby runners, should try to move towards 
-          if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 1000) {
-            //TODO another nested if to check if there is a nearby power up, which is still a pain to do
-            //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners"), *GetDebugName(this)));
-            lastDecision = 1;
-            reactionTime = FMath::RandRange(4,12);
-          }
-        }
+          if (frameCounter >= reactionTime && player_runner != NULL) {
+            
+            // there are no nearby runners, should try to move towards 
+            if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 1000) {
+              //TODO another nested if to check if there is a nearby power up, which is still a pain to do
+              GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners"), *GetDebugName(this)));
+              lastDecision = 1;
+              reactionTime = FMath::RandRange(4,12);
+            }
         
-	else if (defensive) {
-	        if(frameCounter >= reactionTime || lastDecision == 0) {
-	         // GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("defensive"), *GetDebugName(this)));
-	          MoveAwayFromPlayer(player_location, player_direction);
-	          ThrottleInput(-1.0f);
-	          lastDecision = 0;
-	          reactionTime = FMath::RandRange(4,12);
+        
+            else if (defensive) {
+              if(frameCounter >= reactionTime || lastDecision == 0) {
+                GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("defensive: move away"), *GetDebugName(this)));
+                MoveAwayFromPlayer(player_location, player_direction);
+                ThrottleInput(-1.0f);
+                lastDecision = 0;
+                reactionTime = FMath::RandRange(4,12);
 
-	        }
-	}
-	else {
-	  if(frameCounter >= reactionTime || lastDecision == 0) {
-	    //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("!defensive"), *GetDebugName(this)));
-	    MoveTowardsPlayer(player_location, player_direction);
-	    ThrottleInput(1.0f);
-	    lastDecision = 0;
-            reactionTime = FMath::RandRange(4,12);
-	  }
-	}
+              }
+            }
+            else {
+              if(frameCounter >= reactionTime || lastDecision == 0) {
+                GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("move towards"), *GetDebugName(this)));
+                MoveTowardsPlayer(player_location, player_direction);
+                ThrottleInput(1.0f);
+                lastDecision = 0;
+                reactionTime = FMath::RandRange(4,12);
+              }
+            }
+          }
 
 }
 
@@ -460,6 +466,7 @@ void AAIActor::MoveTowardsPlayer(FVector player_location, FRotator player_direct
 	auto turn_rotation = UKismetMathLibrary::FindLookAtRotation(player_location, curr_location);
 	auto turn_angle_manhattan = turn_rotation.GetManhattanDistance(curr_direction);
 
+        
 	if (turn_angle_manhattan < max_angle && turn_angle_manhattan > min_angle) {
 		Mover->SetSteeringInput(turn_angle_manhattan);
 	}

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -218,12 +218,14 @@ void AAIActor::MoveDecision(FVector location) {
 
   // auto player_location = GetWorld()->GetFirstPlayerController()->GetPawn()->GetActorLocation();
   auto closest_runner = ARunnerObserver::GetClosestRunner(*this);
+  auto closest_powerup = ARunnerObserver::GetClosestPowerup(*this);
   if (!closest_runner->isAI) {
     player_runner = closest_runner;
   }
   
   // auto closest_runner = ARunnerObserver::GetPlayer(*this);
   auto player_location = closest_runner->GetActorLocation();
+  auto powerup_location = closest_powerup->GetActorLocation();
   auto player_direction = GetWorld()->GetFirstPlayerController()->GetPawn()->GetActorRotation();
 
   auto curr_location = GetActorLocation();

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -235,31 +235,33 @@ void AAIActor::MoveDecision(FVector location) {
   reverse = dir.Equals(FVector::ForwardVector);
 
   //this vector may be coming from the center of objects, which is why runners used to continuously run into objects
-  if (!dir.Equals(FVector(0.0f, 0.0f, 0.0f))) {
-    if (dir.Equals(FVector::ForwardVector)) {
-      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
-      Mover->SetSteeringInput(-1.0f);
-      ThrottleInput(-1.0f);
-    }
-    else if (dir.Equals(FVector::LeftVector)) {
-      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward"), *GetDebugName(this)));
-      Mover->SetSteeringInput(1.0f);
-      ThrottleInput(1.0f);
-    }
-    else if (dir.Equals(FVector::RightVector)) {
-      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward"), *GetDebugName(this)));
-      Mover->SetSteeringInput(-1.0f);
-      ThrottleInput(1.0f);
-    }
-    else if (dir.Equals((FVector::LeftVector + FVector::ForwardVector))) {
-      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward reverse"), *GetDebugName(this)));
-      Mover->SetSteeringInput(1.0f);
-      ThrottleInput(-1.0f);
-    }
-    else if (dir.Equals((FVector::RightVector + FVector::ForwardVector))) {
-      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward reverse"), *GetDebugName(this)));
-      Mover->SetSteeringInput(-1.0f);
-      ThrottleInput(-1.0f);
+  if(!frameCounter % 10000 == 0) { 
+    if (!dir.Equals(FVector(0.0f, 0.0f, 0.0f))) {
+      if (dir.Equals(FVector::ForwardVector)) {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
+        Mover->SetSteeringInput(-0.3f);
+        ThrottleInput(-1.0f);
+      }
+      else if (dir.Equals(FVector::LeftVector)) {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward"), *GetDebugName(this)));
+        Mover->SetSteeringInput(0.3f);
+        ThrottleInput(1.0f);
+      }
+      else if (dir.Equals(FVector::RightVector)) {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward"), *GetDebugName(this)));
+        Mover->SetSteeringInput(-0.3f);
+        ThrottleInput(1.0f);
+      }
+      else if (dir.Equals((FVector::LeftVector + FVector::ForwardVector))) {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward reverse"), *GetDebugName(this)));
+        Mover->SetSteeringInput(0.3f);
+        ThrottleInput(-1.0f);
+      }
+      else if (dir.Equals((FVector::RightVector + FVector::ForwardVector))) {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward reverse"), *GetDebugName(this)));
+        Mover->SetSteeringInput(-0.3f);
+        ThrottleInput(-1.0f);
+      }
     }
   }
 
@@ -267,7 +269,7 @@ void AAIActor::MoveDecision(FVector location) {
           if (frameCounter >= reactionTime && player_runner != NULL) {
             
             // there are no nearby runners, should try to move towards 
-            if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 1000) {
+            if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 100) {
               //TODO another nested if to check if there is a nearby power up, which is still a pain to do
               GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners"), *GetDebugName(this)));
               lastDecision = 1;
@@ -287,7 +289,7 @@ void AAIActor::MoveDecision(FVector location) {
             }
             else {
               if(frameCounter >= reactionTime || lastDecision == 0) {
-                GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("move towards"), *GetDebugName(this)));
+                GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("move towards player"), *GetDebugName(this)));
                 MoveTowardsPlayer(player_location, player_direction);
                 ThrottleInput(1.0f);
                 lastDecision = 0;

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -235,7 +235,6 @@ void AAIActor::MoveDecision(FVector location) {
   reverse = dir.Equals(FVector::ForwardVector);
 
   //this vector may be coming from the center of objects, which is why runners used to continuously run into objects
-  if(!frameCounter % 10000 == 0) { 
     if (!dir.Equals(FVector(0.0f, 0.0f, 0.0f))) {
       if (dir.Equals(FVector::ForwardVector)) {
         GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
@@ -263,7 +262,7 @@ void AAIActor::MoveDecision(FVector location) {
         ThrottleInput(-1.0f);
       }
     }
-  }
+  
 
           
           if (frameCounter >= reactionTime && player_runner != NULL) {

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -208,6 +208,7 @@ FVector AAIActor::GetDirection() {
 	return result;
 }
 
+
 void AAIActor::MoveDecision(FVector location) {
   if (count != update_rate) {
     count++;
@@ -237,40 +238,40 @@ void AAIActor::MoveDecision(FVector location) {
   //this vector may be coming from the center of objects, which is why runners used to continuously run into objects
     if (!dir.Equals(FVector(0.0f, 0.0f, 0.0f))) {
       if (dir.Equals(FVector::ForwardVector)) {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
+        //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("forward reverse"), *GetDebugName(this)));
         Mover->SetSteeringInput(-0.3f);
         ThrottleInput(-1.0f);
       }
       else if (dir.Equals(FVector::LeftVector)) {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward"), *GetDebugName(this)));
+        //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward"), *GetDebugName(this)));
         Mover->SetSteeringInput(0.3f);
         ThrottleInput(1.0f);
       }
       else if (dir.Equals(FVector::RightVector)) {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward"), *GetDebugName(this)));
+        //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward"), *GetDebugName(this)));
         Mover->SetSteeringInput(-0.3f);
         ThrottleInput(1.0f);
       }
       else if (dir.Equals((FVector::LeftVector + FVector::ForwardVector))) {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward reverse"), *GetDebugName(this)));
+        //Engine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("left forward reverse"), *GetDebugName(this)));
         Mover->SetSteeringInput(0.3f);
         ThrottleInput(-1.0f);
       }
       else if (dir.Equals((FVector::RightVector + FVector::ForwardVector))) {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward reverse"), *GetDebugName(this)));
+        //GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("right forward reverse"), *GetDebugName(this)));
         Mover->SetSteeringInput(-0.3f);
         ThrottleInput(-1.0f);
       }
     }
   
-
-          
-          if (frameCounter >= reactionTime && player_runner != NULL) {
+   if (frameCounter >= reactionTime && player_runner != NULL) {
             
             // there are no nearby runners, should try to move towards 
-            if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 100) {
+            if (ARunnerObserver::GetRunnerDistance(*this, *player_runner) > 5000) {
               //TODO another nested if to check if there is a nearby power up, which is still a pain to do
-              GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners"), *GetDebugName(this)));
+              // get closest power up
+              
+              GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Green, FString::Printf(TEXT("no nearby runners,"), *GetDebugName(this)));
               lastDecision = 1;
               reactionTime = FMath::RandRange(4,12);
             }
@@ -477,6 +478,27 @@ void AAIActor::MoveTowardsPlayer(FVector player_location, FRotator player_direct
 	else {
 		Mover->SetSteeringInput(min_angle);
 	}
+}
+
+void AAIActor::MoveTowardsPowerUp(FVector powerup_location)
+{
+  auto curr_location = GetActorLocation();
+  auto curr_direction = GetActorRotation();
+
+
+  auto turn_rotation = UKismetMathLibrary::FindLookAtRotation(powerup_location, curr_location);
+  auto turn_angle_manhattan = turn_rotation.GetManhattanDistance(curr_direction);
+
+        
+  if (turn_angle_manhattan < max_angle && turn_angle_manhattan > min_angle) {
+    Mover->SetSteeringInput(turn_angle_manhattan);
+  }
+  else if (turn_angle_manhattan > max_angle) {
+    Mover->SetSteeringInput(max_angle);
+  }
+  else {
+    Mover->SetSteeringInput(min_angle);
+  }
 }
 
 void AAIActor::UpdateLocation(FVector point)

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -16,7 +16,6 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "AIActor.generated.h"
-
 /**
  * Struct to store and access difficulty parameters for AI actors
  */

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -158,6 +158,7 @@ public:
 	void MoveDecision(FVector location); //called in Tick to make move decision every 3 frames
 	void MoveAwayFromPlayer(FVector player_location, FRotator player_direction);
 	void MoveTowardsPlayer(FVector player_location, FRotator player_direction);
+        void MoveTowardsPowerUp(FVector player_location);
 	void ShotDecision(FVector location); //called in Tick to make a shot decision every 30 frames
 	void UpdateDifficulty(FName difficulty);
 private:

--- a/Source/BroncoDrome/StageActors/AISpawner.cpp
+++ b/Source/BroncoDrome/StageActors/AISpawner.cpp
@@ -21,6 +21,7 @@ AActor* AAISpawner::Spawn(FName difficultySetting)
   FRotator rotator = UKismetMathLibrary::FindLookAtRotation(this->GetActorLocation(),FVector(0.0f,0.0f,0.0f));
   AAIActor *ai = GetWorld()->SpawnActor<AAIActor>(ActorToSpawn, loc, rotator);
   amountSpawned++;
+  spawnEnabled = false;
   return ai;
 }
 

--- a/Source/BroncoDrome/StageActors/PowerUp.h
+++ b/Source/BroncoDrome/StageActors/PowerUp.h
@@ -6,6 +6,7 @@
 #include "GameFramework/Actor.h"
 #include "PowerUp.generated.h"
 
+
 UCLASS()
 class BRONCODROME_API APowerUp : public AActor
 {

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
@@ -43,7 +43,7 @@ APowerUpMaster::APowerUpMaster()
 void APowerUpMaster::BeginPlay()
 {
 	Super::BeginPlay();
-        ARunnerObserver::RegisterPowerup(*this);
+        //APowerUp* powerup = (APowerUp*) this;
 
 	if (canExpire)
 		GetWorldTimerManager().SetTimer(PowerUpStatusHandler, this, &APowerUpMaster::ShowExpiration, 9.0f, false);
@@ -89,7 +89,8 @@ void APowerUpMaster::HideActor()
 	if (timeTracker <= 0) {
 		SetActorEnableCollision(false);
 		Destroy(); //Remove actor when its time is up.
-	        ARunnerObserver::DeregisterPowerup(*this);
+	        //APowerUp* powerup = (APowerUp*) this;
+	       // ARunnerObserver::DeregisterPowerup(*powerup);
 	}
 
 	SetActorTickEnabled(!hidden);
@@ -158,6 +159,7 @@ void APowerUpMaster::ExecuteFunction(UPrimitiveComponent* OverlappedComp, AActor
         
 		powerupSpawner->PowerUpDestroyed();
 		Destroy(); //Remove actor when picked up
+	        ARunnerObserver::externalUpdatePowerup();
 	}
 
 }

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.cpp
@@ -3,6 +3,7 @@
 #include "../../StageActors/Spawner.h"
 #include "../../Runner/Runner.h"
 #include "../../StageActors/ParticleSpawner.h"
+#include "BroncoDrome/StageActors/RunnerObserver.h"
 
 #include "Sound/SoundCue.h"
 #include "Components/InputComponent.h"
@@ -42,6 +43,7 @@ APowerUpMaster::APowerUpMaster()
 void APowerUpMaster::BeginPlay()
 {
 	Super::BeginPlay();
+        ARunnerObserver::RegisterPowerup(*this);
 
 	if (canExpire)
 		GetWorldTimerManager().SetTimer(PowerUpStatusHandler, this, &APowerUpMaster::ShowExpiration, 9.0f, false);
@@ -87,6 +89,7 @@ void APowerUpMaster::HideActor()
 	if (timeTracker <= 0) {
 		SetActorEnableCollision(false);
 		Destroy(); //Remove actor when its time is up.
+	        ARunnerObserver::DeregisterPowerup(*this);
 	}
 
 	SetActorTickEnabled(!hidden);

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.h
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.h
@@ -4,10 +4,11 @@
 #include "GameFramework/Actor.h"
 #include "Blueprint/UserWidget.h"
 #include "PowerUpSpawner.h"
+#include "BroncoDrome/StageActors/PowerUp.h"
 #include "PowerUpMaster.generated.h"
 
 UCLASS()
-class BRONCODROME_API APowerUpMaster : public AActor
+class BRONCODROME_API APowerUpMaster : public APowerUp
 {
 	GENERATED_BODY()
 

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.h
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpMaster.h
@@ -8,7 +8,7 @@
 #include "PowerUpMaster.generated.h"
 
 UCLASS()
-class BRONCODROME_API APowerUpMaster : public APowerUp
+class BRONCODROME_API APowerUpMaster : public AActor
 {
 	GENERATED_BODY()
 

--- a/Source/BroncoDrome/StageActors/PowerUp/PowerUpSpawner.cpp
+++ b/Source/BroncoDrome/StageActors/PowerUp/PowerUpSpawner.cpp
@@ -3,6 +3,8 @@
 
 #include "PowerUpSpawner.h"
 #include "PowerUpMaster.h"
+#include "BroncoDrome/StageActors/RunnerObserver.h"
+
 #include <BroncoDrome/BroncoSaveGame.h>
 #include <Runtime/Engine/Classes/Kismet/GameplayStatics.h>
 

--- a/Source/BroncoDrome/StageActors/RunnerObserver.h
+++ b/Source/BroncoDrome/StageActors/RunnerObserver.h
@@ -5,7 +5,9 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include <set>
-
+#include "PowerUp.h"
+#include"PowerUp/PowerUpMaster.h"
+#include"PowerUp/PowerUpSpawner.h"
 #include "RunnerObserver.generated.h"
 
 
@@ -30,7 +32,10 @@ private:	// Member
 
 	// Set of all managed Runners
 	std::set<class ARunner*> m_RunnerRegister;
-        std::set<class APowerUp*> m_PowerupRegister;
+        TArray<AActor*> powerups;
+        FTimerHandle GameTimeHandler;
+        int frameCount;
+
 
 public:		// Public Static API
 
@@ -38,13 +43,13 @@ public:		// Public Static API
 	static ARunnerObserver* SingletonInstance;
 
 
+
+
 	// Pretty much the DMV
 	static void RegisterRunner(class ARunner& runner);
 	static void DeregisterRunner(class ARunner& runner);
 
-        // Not the DMV
-        static void RegisterPowerup(class APowerUp& powerup);
-        static void DeregisterPowerup(class APowerUp& powerup);
+
 
         // get all actors of class
          template<typename T>
@@ -53,20 +58,24 @@ public:		// Public Static API
 
 	// Runner visibility tests
 	static class ARunner* GetClosestRunner(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(), 
-		float angularThreshold = 180.f, bool raycastTest = false);
-  static class APowerUp* GetClosestPowerup(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(), 
+	float angularThreshold = 180.f, bool raycastTest = false);
+        static AActor* GetClosestPowerup(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(), 
         float angularThreshold = 180.f, bool raycastTest = false);
 	static class ARunner* GetPlayer(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(),
-		float angularThreshold = 180.f, bool raycastTest = false);
+	float angularThreshold = 180.f, bool raycastTest = false);
 	static float GetRunnerDistance(const class ARunner& fromRunner, const class ARunner& toRunner);
-        static float GetPowerupDistance(const class ARunner& fromRunner, const class APowerUp& toPowerup);
+        static float GetPowerupDistance(const class ARunner& fromRunner, const class AActor& toPowerup);
 
 	static float GetAngleBetweenRunners(const class ARunner& fromRunner, const class ARunner& toRunner, bool fromCamera = true);
 	static bool RunnerRaycastTest(const class ARunner& fromRunner, const class ARunner& toRunner);
-        static float GetAngleBetweenPowerups(const class ARunner& fromRunner, const class APowerUp& toPowerup, bool fromCamera = true);
-        static bool PowerupRaycastTest(const class ARunner& fromRunner, const class APowerUp& toPowerup);
+        static float GetAngleBetweenPowerups(const class ARunner& fromRunner, const AActor& toPowerup, bool fromCamera = true);
+        static bool PowerupRaycastTest(const class ARunner& fromRunner, const class AActor& toPowerup);
 	static bool IsRunnerVisible(const class ARunner& fromRunner, const class ARunner& toRunner,
 		float maxDistance = std::numeric_limits<float>::max(), float angularThreshold = 180.f, bool raycastTest = false);
-        static bool IsPowerupVisible(const class ARunner& fromRunner, const class APowerUp& toRunner,
+      void UpdatePowerups();
+
+        static bool IsPowerupVisible(const class ARunner& fromRunner, const class AActor& toRunner,
               float maxDistance = std::numeric_limits<float>::max(), float angularThreshold = 180.f, bool raycastTest = false);
+        static void externalUpdatePowerup();
+
 };

--- a/Source/BroncoDrome/StageActors/RunnerObserver.h
+++ b/Source/BroncoDrome/StageActors/RunnerObserver.h
@@ -30,15 +30,21 @@ private:	// Member
 
 	// Set of all managed Runners
 	std::set<class ARunner*> m_RunnerRegister;
+        std::set<class APowerUp*> m_PowerupRegister;
 
 public:		// Public Static API
 
 	// Singleton instance
 	static ARunnerObserver* SingletonInstance;
 
+
 	// Pretty much the DMV
 	static void RegisterRunner(class ARunner& runner);
 	static void DeregisterRunner(class ARunner& runner);
+
+        // Not the DMV
+        static void RegisterPowerup(class APowerUp& runner);
+        static void DeregisterPowerup(class APowerUp& runner);
 
         // get all actors of class
          template<typename T>
@@ -48,9 +54,13 @@ public:		// Public Static API
 	// Runner visibility tests
 	static class ARunner* GetClosestRunner(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(), 
 		float angularThreshold = 180.f, bool raycastTest = false);
+  static class APowerUp* GetClosestPowerup(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(), 
+        float angularThreshold = 180.f, bool raycastTest = false);
 	static class ARunner* GetPlayer(const class ARunner& fromRunner, float maxDistance = std::numeric_limits<float>::max(),
 		float angularThreshold = 180.f, bool raycastTest = false);
 	static float GetRunnerDistance(const class ARunner& fromRunner, const class ARunner& toRunner);
+        static float GetPowerupDistance(const class ARunner& fromRunner, const class APowerUp& toPowerup);
+
 	static float GetAngleBetweenRunners(const class ARunner& fromRunner, const class ARunner& toRunner, bool fromCamera = true);
 	static bool RunnerRaycastTest(const class ARunner& fromRunner, const class ARunner& toRunner);
 	static bool IsRunnerVisible(const class ARunner& fromRunner, const class ARunner& toRunner,

--- a/Source/BroncoDrome/StageActors/RunnerObserver.h
+++ b/Source/BroncoDrome/StageActors/RunnerObserver.h
@@ -63,6 +63,10 @@ public:		// Public Static API
 
 	static float GetAngleBetweenRunners(const class ARunner& fromRunner, const class ARunner& toRunner, bool fromCamera = true);
 	static bool RunnerRaycastTest(const class ARunner& fromRunner, const class ARunner& toRunner);
+        static float GetAngleBetweenPowerups(const class ARunner& fromRunner, const class APowerUp& toPowerup, bool fromCamera = true);
+        static bool PowerupRaycastTest(const class ARunner& fromRunner, const class APowerUp& toPowerup);
 	static bool IsRunnerVisible(const class ARunner& fromRunner, const class ARunner& toRunner,
 		float maxDistance = std::numeric_limits<float>::max(), float angularThreshold = 180.f, bool raycastTest = false);
+        static bool IsPowerupVisible(const class ARunner& fromRunner, const class APowerUp& toRunner,
+              float maxDistance = std::numeric_limits<float>::max(), float angularThreshold = 180.f, bool raycastTest = false);
 };

--- a/Source/BroncoDrome/StageActors/RunnerObserver.h
+++ b/Source/BroncoDrome/StageActors/RunnerObserver.h
@@ -43,8 +43,8 @@ public:		// Public Static API
 	static void DeregisterRunner(class ARunner& runner);
 
         // Not the DMV
-        static void RegisterPowerup(class APowerUp& runner);
-        static void DeregisterPowerup(class APowerUp& runner);
+        static void RegisterPowerup(class APowerUp& powerup);
+        static void DeregisterPowerup(class APowerUp& powerup);
 
         // get all actors of class
          template<typename T>


### PR DESCRIPTION
This turned into a bit of a mess and I am very sorry for the horrendous formatting and git documentation / traceability. I really need to improve that in the future. 

Changes 

- [x] AI has a basic reaction time system implemented. When reacting to similar or the same stimulus, their reaction time is near instant. When reacting to a new stimulus, the reaction time is higher. 

- [x] AI can now move towards and collect power ups

- [x] AI no longer drive endlessly in circles when near obstacles

- [x] AI no longer drive endlessly in circles when in combat with the player

- [x] AI perform basic swerving evasive maneuvers when traversing to players

- [x] AI will now prioritize getting power ups when there are no nearby runners


References Stories:

#251 - implement ai runner reaction time 

#152 - AI move toward power-ups

#241 - AI prioritize power ups

Work logs:

11/3 Worked for 1.5 hours on AI movement. AI actors no longer move in circles when there is a nearby wall. Spent the majority of the time reviewing code from the previous semesters and testing various solutions.

11/19 Worked 1.5 hours on ai movement. Implemented pretty much all of the functionality needed to move towards powerups

11/20 Worked .75 minutes with Andrew and tavi on movement. Currently facing issues with the class hierarchy of powerups.

11/21 Worked 1.25 hours on movement. Fixed the behavior of AI runners driving in circles while in combat with the player.

11/22 worked for 1.5 hours on movement. 30 minutes of which was with Nathan. Still no clue on movement towards powerups

11/30 Worked 3.75 hours on ai movement. Finally got move towards powerup implemented with the help of Andrew. Functional requirements are now met.

