### PR TITLE
448 fps cap and framerate independent ai behavior

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -10,6 +10,9 @@ AppliedDefaultGraphicsPerformance=Maximum
 +ActiveGameNameRedirects=(OldGameName="TP_Blank",NewGameName="/Script/BroncoDrome")
 +ActiveGameNameRedirects=(OldGameName="/Script/TP_Blank",NewGameName="/Script/BroncoDrome")
 +ActiveClassRedirects=(OldClassName="TP_BlankGameModeBase",NewClassName="BroncoDromeGameModeBase")
+bSmoothFrameRate=True
+SmoothedFrameRateRange=(LowerBound=(Type=Inclusive,Value=22.000000),UpperBound=(Type=Exclusive,Value=60.000000))
+MinDesiredFrameRate=30.000000
 
 [/Script/EngineSettings.GameMapsSettings]
 EditorStartupMap=/Game/Maps/MenuLevel.MenuLevel

--- a/Source/BroncoDrome/Runner/LoseWidget.cpp
+++ b/Source/BroncoDrome/Runner/LoseWidget.cpp
@@ -1,7 +1,7 @@
 // // Copyright (C) Team Gregg 2022. All Rights Reserved.
+#include "LoseWidget.h"
 #include "BroncoDrome/BroncoSaveGame.h"
 #include "Kismet/GameplayStatics.h"
-#include "LoseWidget.h"
 
 void ULoseWidget::NativePreConstruct()
 {

--- a/Source/BroncoDrome/Runner/Runner.cpp
+++ b/Source/BroncoDrome/Runner/Runner.cpp
@@ -478,6 +478,9 @@ void ARunner::ResetCamera()
 	SpringArm->SetRelativeRotation(FRotator(0.f, 0.f, 0.f));
 }
 
+// NOTE: UE4 Chaos Vehicles physics is based on system FRAMERATE. This means that jumping (and car handling) will behave different at different FPS
+// The only workaround I could come up with was to use an FPS cap so that behavior is at least more similar across systems (currently set to 60fps)
+// Otherwise, it is necessary to rebuild the vehicle system with your own physics system or a different plugin that utilizes physics substepping
 void ARunner::Hop()
 {
 	// Only hop if Runner is grounded

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -103,7 +103,7 @@ public: // Constants
 
 	// Input
 	const float LOOK_BEHIND_THRESHOLD = .7f;
-	const float HOP_FORCE_AMOUNT = 68000.f;
+	const float HOP_FORCE_AMOUNT = 35000.f;
 	const float ROTATION_FIX_THRESHOLD = 32.5f;
 	const float ROTATION_FIX_FORCE = 1000.f;
 

--- a/Source/BroncoDrome/Runner/Runner.h
+++ b/Source/BroncoDrome/Runner/Runner.h
@@ -1,5 +1,10 @@
 // // Copyright (C) Dromies 2021. All Rights Reserved.
 // // Copyright (C) Team Gregg 2022. All Rights Reserved.
+// // Copyright (C) Kitty Cat Studios 2022. All Rights Reserved.
+
+// NOTE (fall 2022): UE4 Chaos Vehicles physics is based on system FRAMERATE. This means that jumping (and car handling) will behave different at different FPS
+// The only workaround I could come up with was to use an FPS cap so that behavior is at least more similar across systems (currently set to 60fps)
+// Otherwise, it is necessary to rebuild the vehicle system with your own physics system or a different plugin that utilizes physics substepping
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/BroncoDrome/StageActors/AIActor.cpp
+++ b/Source/BroncoDrome/StageActors/AIActor.cpp
@@ -91,17 +91,17 @@ void AAIActor::Tick(float DeltaTime)
   
         currPos = this->GetActorLocation();
 
-        if(pos_buffer > 0 && pos_buffer < 60) {
+        if(pos_buffer > 0 && pos_buffer < pos_buffer_threshold) {
           ThrottleInput(-1.0f);
-          pos_buffer++;
-          if(pos_buffer == 59)
+          pos_buffer += (pos_buffer_threshold * DeltaTime);
+          if(pos_buffer >= 59)
             pos_buffer = 0;
         //  GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("STUCK! REVERSE"), *GetDebugName(this)));
           return;
         }
         if(currPos.Equals(prevPos,8)) {
-          pos_counter++;
-          if(pos_counter > 50) {
+          pos_counter += (pos_counter_threshold * DeltaTime);
+          if(pos_counter > pos_counter_threshold) {
             ThrottleInput(-1.0f);
             pos_buffer = 1;
          //   GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT("STUCK! REVERSE"), *GetDebugName(this)));

--- a/Source/BroncoDrome/StageActors/AIActor.h
+++ b/Source/BroncoDrome/StageActors/AIActor.h
@@ -122,6 +122,8 @@ public:
 	int aiId;
 	int shot_rate = 90; //interval for AI shots //0=90; 1= 50; 2= 70;
 	float accuracyRange; // sets accuracy of AI Runners shot
+	float pos_buffer_threshold = 60.0f;
+	float pos_counter_threshold = 50.0f;
 
         // reaction time variables
         int frameCounter = 0;


### PR DESCRIPTION
Closes #448

Unreal Engine Chaos Vehicles physics system is based on the framerate the game is running at. This regretfully means that we have to use an arbitrary 60fps cap so that the game will perform the same across systems.

In addition, the AI was basing some of its decisions off framerate which was affecting their behavior as well so it was changed to be independent of framerate using the deltatime parameter of tick.