### PR TITLE
Centered Powerup Pickup Text

### DIFF
--- a/Content/Blueprints/UI/PowerupWidget.uasset
+++ b/Content/Blueprints/UI/PowerupWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:449203c970b5847b24b5f09609ce3a32cf3fd483693609f930d2c2b6843486de
-size 60775
+oid sha256:8ab98e9bb26cb43be13268d2e8419f03871e23139c55a1e2315dfc2dd8bf484f
+size 60288


### PR DESCRIPTION
Whenever picking up powerups, the text that flashed at the top of the screen wasn't centered. This has been fixed.